### PR TITLE
Replace hardcoded CG solver with scipy for TVD.

### DIFF
--- a/src/daria/utils/regularization.py
+++ b/src/daria/utils/regularization.py
@@ -3,15 +3,16 @@ from __future__ import annotations
 from typing import Callable
 import daria as da
 import numpy as np
+import scipy.sparse as sps
+from scipy.sparse.linalg import LinearOperator
+import skimage
 
 from daria.utils.norms import frobenius_norm
-
 
 def tv_denoising(
     img: da.Image,
     mu: float,
     l: float,
-    solver: da.Solver = da.CG(da.StoppingCriterion(0.01, 100, da.frobenius_norm)),
     stoppingCriterion: da.StoppingCriterion = da.StoppingCriterion(
         0.01, 100, da.frobenius_norm
     ),
@@ -24,21 +25,16 @@ def tv_denoising(
         img (daria.Image): Image that should be regularized
         mu (float): Regularization coefficient
         l (float): Penalty coefficient from Goldstein and Osher's algorithm
-        solver (daria.Solver): Linear solver, default is Conjugate Gradients
         stoppingCriterion (daria.StoppingCriterion): stopping criterion containing information about tolerance, maximum number of iterations and norm
         verbose (bool): Set to true
     """
 
     # Set verbosity of stopping criterion
     stoppingCriterion.verbose = verbose
-    solver.stoppingCriterion.verbose = verbose
-
-    # Make a copy of the original image for return
-    reg_image = img.copy()
 
     # Extract the two images
-    rhs = img.img
-    im = reg_image.img
+    rhs = skimage.util.img_as_float(img.img)
+    im = skimage.util.img_as_float(img.img)
 
     # Create algorithm specific functionality
     dx = np.zeros(rhs.shape)
@@ -46,9 +42,13 @@ def tv_denoising(
     bx = np.zeros(rhs.shape)
     by = np.zeros(rhs.shape)
 
-    # Left-hand-side operator
-    def lhsoperator(x: np.ndarray):
-        return mu * x - l * da.laplace(x)
+    # Left-hand-side operator defined as a linear operator acting on flat images
+    def mv(x: np.ndarray) -> np.ndarray:
+        # Since the Laplace operator acts on 2d images, need to reshape first # FIXME try to rewrite laplace?
+        x = np.reshape(x, im.shape[:2])
+        return (mu * x - l * da.laplace(x)).flatten()
+    im_size = im.shape[0] * im.shape[1]
+    lhsoperator = LinearOperator((im_size, im_size), matvec=mv) 
 
     # Right-hand-side operator
     def rhsoperator(rhs, dx, dy, bx, by):
@@ -56,19 +56,32 @@ def tv_denoising(
 
     def shrink(x):
         n = da.frobenius_norm(x)
-        return x / n * max(n - 1 / l, 0)
+        return x / n * max(n - 1. / l, 0.)
 
-    iterations = 0
-    increment = im
+    iterations: int = 0
+    increment: np.ndarray = im.copy()
 
+    # TVD algorithm from Goldstein and Osher, cf doi:10.1137/080725891
     while not (stoppingCriterion.check_relative(increment, im, iterations)):
         im_old = np.ndarray.copy(im)
-        im = solver.apply(lhsoperator, rhsoperator(rhs, dx, dy, bx, by), im)
+        im = np.reshape(
+            sps.linalg.cg(
+                lhsoperator,
+                rhsoperator(rhs, dx, dy, bx, by).flatten(),
+                im.flatten(),
+                tol = 1e-2,
+                maxiter = 100
+            )[0],
+            im.shape[:2]
+        )
         dx = shrink(da.backward_diff_x(im) + bx)
         dy = shrink(da.backward_diff_y(im) + by)
         bx = bx + da.backward_diff_x(im) - dx
         by = by + da.backward_diff_y(im) - dy
         increment = im - im_old
         iterations += 1
-    reg_image.img = im.astype(np.uint8)
-    return reg_image
+
+    # Convert to correct format
+    img.img = skimage.util.img_as_ubyte(im)
+
+    return img


### PR DESCRIPTION
So far, the TVD algorithm has used a hand-coded CG solver. It has been replaced by the corresponding version from scipy. This has two effects: The performance of applying TVD is improved, e.g., from 40 seconds to 9 seconds. Furthermore, the scipy implementation allows for using tailored preconditioners to futher improve the performance, e.g. multigrid solvers.