### PR TITLE
Add simple resize method which keeps the aspect ratio

### DIFF
--- a/src/daria/utils/resolution.py
+++ b/src/daria/utils/resolution.py
@@ -1,0 +1,23 @@
+"""
+Utiliy functions for transforming resolution.
+"""
+
+import cv2
+import numpy as np
+
+
+def resize(img: np.ndarray, scale_percent: float = 100) -> np.ndarray:
+    """
+    Resizes image while keeping the aspect ratio.
+
+    Args:
+        img (np.ndarray): image array
+        scale_percent (float): positive scaling factor (in %)
+
+    Returns:
+        np.ndarray: resized image
+    """
+    width = int(img.shape[1] * scale_percent / 100)
+    height = int(img.shape[0] * scale_percent / 100)
+    dim = (width, height)
+    return cv2.resize(img, dim, interpolation=cv2.INTER_AREA)


### PR DESCRIPTION
More tailored routines may be collected in the future. For now, a simple and standard resizing routine is implemented. Anticipating an often need for such a resizing method, the decision is to collect such workflows in standard routines.