### PR TITLE
Aim at consistent use for indexing and arrays.

### DIFF
--- a/examples/segmentation_watershed.py
+++ b/examples/segmentation_watershed.py
@@ -13,7 +13,7 @@ from scipy import ndimage as ndi
 
 # Color image
 # TODO: provide path to baseline image
-image_color = cv2.imread("../images/fluidflower/Baseline.jpg")
+image_color = cv2.imread("images/Baseline_fullresolution.jpg")
 
 # Consider 1d image, either gray or green channel (blue and red channels did not lead to any reasonable results in short time)
 image = cv2.cvtColor(image_color, cv2.COLOR_BGR2GRAY)

--- a/src/daria/analysis/compaction.py
+++ b/src/daria/analysis/compaction.py
@@ -134,11 +134,7 @@ class CompactionAnalysis:
                     translation,
                     intact_translation,
                 ) = self.translationEstimator.find_effective_translation(
-                    img_src.img,
-                    img_dst.img,
-                    None,
-                    None,
-                    plot_matches=False,
+                    img_src.img, img_dst.img, None, None, plot_matches=False
                 )
 
                 # The above procedure to find a matching transformation is successful if in
@@ -266,26 +262,15 @@ class CompactionAnalysis:
         interpolated_patch_translation_x = interpolator_translation_x(input_arg)
         interpolated_patch_translation_y = interpolator_translation_y(input_arg)
 
-        # Convert coordinates of patch centers to pixels - using the (row, col) ordering
+        # Convert coordinates of patch centers to pixels - using the matrix indexing
         patch_centers_x_pixels = np.zeros(tuple(reversed(self.N_patches)), dtype=int)
         patch_centers_y_pixels = np.zeros(tuple(reversed(self.N_patches)), dtype=int)
         for j in range(self.N_patches[1]):
             for i in range(self.N_patches[0]):
                 center = self.patch_centers[i, j]
-                patch_centers_x_pixels[
-                    self.N_patches[1] - 1 - j, i
-                ] = self.img_src.coordinatesystem.coordinateToPixel(
-                    (center[0], center[1])
-                )[
-                    1
-                ]
-                patch_centers_y_pixels[
-                    self.N_patches[1] - 1 - j, i
-                ] = self.img_src.coordinatesystem.coordinateToPixel(
-                    (center[0], center[1])
-                )[
-                    0
-                ]
+                pixel = self.img_src.coordinatesystem.coordinateToPixel(center)
+                patch_centers_x_pixels[self.N_patches[1] - 1 - j, i] = pixel[1]
+                patch_centers_y_pixels[self.N_patches[1] - 1 - j, i] = pixel[0]
 
         # Plot the interpolated translation
         if plot_translation:

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -58,16 +58,18 @@ def simple_curvature_correction(img: np.ndarray, **kwargs) -> np.ndarray:
     # including lense properties. Thus, the task is actually quite hard. Here, a
     # simple approach is used, simply choosing the numerical centre of the image
     # corrected by the user.
+
+    # Image center in pixels, but in (col, row) order
     image_center = [
         round(Nx / 2) + horizontal_center_offset,
         round(Ny / 2) + vertical_center_offset,
     ]
 
-    # Define coordinate system relative to image center, scaled with physical dimensions
-    x = np.array(range(1, Nx + 1)) - image_center[0]
-    y = np.array(range(1, Ny + 1)) - image_center[1]
+    # Define coordinate system relative to image center, in terms of pixels
+    x = np.arange(Nx) - image_center[0]
+    y = np.arange(Ny) - image_center[1]
 
-    # Construct associated meshgrid
+    # Construct associated meshgrid with Cartesian indexing
     X, Y = np.meshgrid(x, y)
 
     # Warp the coordinate system nonlinearly, correcting for bulge and stretch effects.
@@ -84,10 +86,10 @@ def simple_curvature_correction(img: np.ndarray, **kwargs) -> np.ndarray:
 
     # Map corrected grid back to positional arguments, i.e. invert the definition
     # of the local coordinate system
-    Xmod += image_center[0] - 1
-    Ymod += image_center[1] - 1
+    Xmod += image_center[0]
+    Ymod += image_center[1]
 
-    # Create out grid as the corrected grid, but not in meshgrid format
+    # Create out grid as the corrected grid, use (row,col) format
     out_grid = np.array([Ymod.ravel(), Xmod.ravel()])
 
     # Define the shape corrected image.

--- a/src/daria/corrections/shape/curvaturecorrection.py
+++ b/src/daria/corrections/shape/curvaturecorrection.py
@@ -22,8 +22,7 @@ def curvature_correction(
     """
     Curvature correction.
     Arguments:
-        img (np.ndarray): image array, with pixel access, using y, x ordering, such that the
-            top left corner of the image corresponds to the (0,0) pixel.
+        img (np.ndarray): image array
         img (str): path to image, alternative way to feed the actual image.
         width (float): physical width of image.
         height (float): physical height of image.
@@ -65,10 +64,10 @@ def curvature_correction(
     # Curvature corrected grid using input parameters
     Xmod = horizontal_crop * np.multiply(
         np.multiply(X, (1 + horizontal_stretch * (X - horizontal_stretch_mid) ** 2)),
-        (1 - vertical_bulge * Y**2),
+        (1 - vertical_bulge * Y ** 2),
     )
     Ymod = vertical_crop * (
-        np.multiply(Y, (1 - horizontal_bulge * X**2)) - vertical_shear * X
+        np.multiply(Y, (1 - horizontal_bulge * X ** 2)) - vertical_shear * X
     )
 
     # Map corrected grid back to positional arguments

--- a/src/daria/corrections/shape/curvaturecorrection.py
+++ b/src/daria/corrections/shape/curvaturecorrection.py
@@ -64,10 +64,10 @@ def curvature_correction(
     # Curvature corrected grid using input parameters
     Xmod = horizontal_crop * np.multiply(
         np.multiply(X, (1 + horizontal_stretch * (X - horizontal_stretch_mid) ** 2)),
-        (1 - vertical_bulge * Y ** 2),
+        (1 - vertical_bulge * Y**2),
     )
     Ymod = vertical_crop * (
-        np.multiply(Y, (1 - horizontal_bulge * X ** 2)) - vertical_shear * X
+        np.multiply(Y, (1 - horizontal_bulge * X**2)) - vertical_shear * X
     )
 
     # Map corrected grid back to positional arguments

--- a/src/daria/corrections/shape/homography.py
+++ b/src/daria/corrections/shape/homography.py
@@ -6,10 +6,7 @@ import cv2
 import numpy as np
 
 
-def homography_correction(
-    img_src: np.ndarray,
-    **kwargs,
-) -> np.ndarray:
+def homography_correction(img_src: np.ndarray, **kwargs) -> np.ndarray:
     """
     Homography correction for known corner points of a square (default) object.
 
@@ -19,8 +16,8 @@ def homography_correction(
             height (int or float): height of the physical object
             in meters (boolean): controlling whether width and height are float and
                 are meant as in meters; number of pixels otherwise
-            pts_src (array): N points with (x,y) pixel coordinates, N>=4
-            pts_dst (array, optional): N points with (x,y) pixel coordinates, N>=4
+            pts_src (array): N points with pixels in (col,row) format, N>=4
+            pts_dst (array, optional): N points with pixels in (col, row) format, N>=4
     """
 
     # Determine original and target size
@@ -51,6 +48,7 @@ def homography_correction(
         # Assume implicitly that corner points have been provided,
         # and that their orientation is mathematically positive,
         # starting with the top left corner.
+        # Further more use reversed matrix indexing, i.e., (col,row).
         assert pts_src.shape[0] == 4
         pts_dst = np.array(
             [

--- a/src/daria/corrections/shape/translation.py
+++ b/src/daria/corrections/shape/translation.py
@@ -75,10 +75,7 @@ class TranslationEstimator:
             # effective translation (as affine map) as average translation between the
             # matches.
             if self._isclose_translation(transformation):
-                (
-                    translation,
-                    intact_translation,
-                ) = self._find_translation(matches)
+                (translation, intact_translation) = self._find_translation(matches)
             else:
                 translation = None
                 intact_translation = False
@@ -189,10 +186,7 @@ class TranslationEstimator:
 
         # Determine matching points
         (pts_src, pts_dst), have_match, matches = FeatureDetection.match_features(
-            features_src,
-            features_dst,
-            keep_percent=keep_percent,
-            return_matches=True,
+            features_src, features_dst, keep_percent=keep_percent, return_matches=True
         )
 
         # Determine matching transformation. Allow for different models.
@@ -271,6 +265,8 @@ class TranslationEstimator:
         """
         # Extract the translation directly as average displacement from all
         # provided matches - have to assume that the matches are well chosen.
+        # NOTE: As matches will result as output from cv2 routines, these use
+        # (col, row)-indexing, i.e., reverse matrix indexing.
         src, dst = matches
         displacement = np.average(dst - src, axis=0)
         affine_translation = np.hstack((np.eye(2), displacement.reshape((2, 1))))

--- a/src/daria/image/coordinatesystem.py
+++ b/src/daria/image/coordinatesystem.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import math
 from typing import Union
 
 import numpy as np
@@ -12,8 +11,8 @@ class CoordinateSystem:
     """Class for coordinate system for images.
 
     A coordinate system has knowledge about the conversion of pixels (in standard format),
-    i.e., y,x pixels with (0,0) being identified with the top left corner. Conversion maps
-    from pixel to coordinates and vice-versa are provided.
+    i.e., (row,col) format with (0,0) being identified with the top left corner.
+    Conversion maps from pixel to coordinates and vice-versa are provided.
 
     Attributes:
 
@@ -31,27 +30,22 @@ class CoordinateSystem:
         self._dy: float = img.dy
 
         # Determine the coordinate, corresponding to the origin pixel (0,0), i.e.,
-        # the top left corner. NOTE img.origo corresponds to the lower left corner
-        # FIXME make it more consistent throughout files
-        self._coordinate_of_origin_pixel: tuple[float] = (
-            img.origo[0],
-            img.origo[1] + self._height,
+        # the top left corner.
+        self._coordinate_of_origin_pixel: np.ndarray = img.origo + np.array(
+            [0, self._height]
         )
 
         # Determine the pixel, corresponding to the physical origin (0,0)
-        self._pixel_of_origin_coordinate: tuple[int] = self.coordinateToPixel((0, 0))
+        self._pixel_of_origin_coordinate: np.ndarray = self.coordinateToPixel(
+            np.array([0, 0])
+        )
 
         # Determine the bounding box of the image, in physical dimensions,
         # also defining the effective boundaries of the coordinate system.
         # for this, address the lower left and upper right corners.
         xmin, ymin = self.pixelToCoordinate(img.corners["lowerleft"])
         xmax, ymax = self.pixelToCoordinate(img.corners["upperright"])
-        self.domain = {
-            "xmin": xmin,
-            "xmax": xmax,
-            "ymin": ymin,
-            "ymax": ymax,
-        }
+        self.domain = {"xmin": xmin, "xmax": xmax, "ymin": ymin, "ymax": ymax}
 
     def pixelsToLength(
         self, num_pixels: Union[int, np.ndarray], axis: str = "x"
@@ -88,90 +82,94 @@ class CoordinateSystem:
         Returns:
             int or 1d array of ints: number(s) of pixels
         """
+        # Include all touched pixels; use therefore ceil.
         if axis == "x":
-            return (
-                math.ceil(length / self._dx)
-                if isinstance(length, float)
-                else np.ceil(length / self._dx)
-            )
+            return np.ceil(length / self._dx).astype(int)
         elif axis == "y":
-            return (
-                math.ceil(length / self._dy)
-                if isinstance(length, float)
-                else np.ceil(length / self._dy)
-            )
+            return np.ceil(length / self._dy).astype(int)
         else:
             raise ValueError("Axis type not supported.")
 
-    def pixelToCoordinate(self, pixel: tuple[int]) -> tuple[float]:
-        """Conversion from pixel in standard format to coordinate in physical units.
+    def pixelToCoordinate(self, pixel: Union[np.ndarray, list[int]]) -> np.ndarray:
+        """
+        Conversion from pixel to Cartesian coordinate, i.e., from (row,col) to (x,y)
+        format plus scaling.
+
+        Handles both single and multiple pixels.
 
         Arguments:
-            pixel (tuple of int): pixel location; in 2d, first and second arguments hold
-                the y- and x-positions
+            pixel (np.ndarray): pixel location in (row,col) format; one pixel per row
 
         Returns:
-            float: x-coordinate in physical units
-            float: y-coordinate in physical units
+            np.ndarray: corresponding coordinate in (x,y) format
         """
+        # Convert list to array
+        if isinstance(pixel, list):
+            pixel = np.array(pixel)
+        assert isinstance(pixel, np.ndarray)
+
         # Fetch the top left corner.
         x0, y0 = self._coordinate_of_origin_pixel
 
-        # Fetch the single pixel indices - note their order
-        y_pixel, x_pixel = pixel
-
-        # Obtain the coordinate by scaling - for the y-coordinate, one also has to flip
-        # the y-axis due to the convention in numbering of pixels, and therefore subtract.
-        x = x0 + x_pixel / self._num_pixels_width * self._width
-        y = y0 - y_pixel / self._num_pixels_height * self._height
-
-        # Return final coordinates
-        return x, y
-
-    def pixelToCoordinate_for_arrays(self, pixels: np.ndarray) -> np.ndarray:
-        """Conversion from pixel in standard format to coordinate in physical units.
-
-        Arguments:
-            pixels (np.ndarray): pixel locations; in 2d, columns hold row and col image pixels;
-                one row per pixel
-
-        Returns:
-            np.ndarray: coordinates in metric units
-        """
-        # Fetch the top left corner.
-        x0, y0 = self._coordinate_of_origin_pixel
+        # Aim at handling both single pixels stored in a 1d array as well as
+        # multiple pixels stored in a 2d array. Convert to the more general
+        # case.
+        original_shape = pixel.shape
+        pixel = np.atleast_2d(pixel)
 
         # Initialize coordinates
-        coordinates = np.empty_like(pixels, dtype=float)
+        coordinate = np.empty_like(pixel, dtype=float)
 
-        # Obtain the coordinates by scaling - for the y-coordinate, one also has to flip
-        # the y-axis due to the convention in numbering of pixels, and therefore subtract.
-        coordinates[:, 0] = x0 + pixels[:, 0] / self._num_pixels_width * self._width
-        coordinates[:, 1] = y0 + pixels[:, 1] / self._num_pixels_height * self._height
+        # Combine two operations. 1. Convert from (row,col) to (x,y) format and
+        # scale correctly, to obtain the physical coordinates with correct units.
+        coordinate[:, 0] = x0 + pixel[:, 1] / self._num_pixels_width * self._width
+        coordinate[:, 1] = y0 - pixel[:, 0] / self._num_pixels_height * self._height
 
-        return coordinates
+        # Return in same format as the input
+        return coordinate.reshape(original_shape)
 
-    def coordinateToPixel(self, coordinate: tuple[float]) -> tuple[int]:
-        """Conversion from coordinate in physical units to pixel in standard format.
+    def coordinateToPixel(
+        self, coordinate: Union[np.ndarray, list[float]]
+    ) -> np.ndarray:
+        """
+        Conversion from Cartesian coordinate to pixel, from (x,y) to (row,col)
+        format plus scaling.
 
-        Inverse to pixelToCoordinate, modulo rounding.
+        Handles both single and multiple coordinates.
 
         Arguments:
-            coordinate (tuple of float): coordinate in physical units
+            coordinate (np.ndarray): coordinate in (x,y) format; one coordinate per row
 
         Returns:
-            int: pixel index locating the y-coordinate
-            int: pixel index location the x-coordinate
+            np.ndarray: corresponding pixels in (row,col) format
         """
+        # Convert list to array
+        if isinstance(coordinate, list):
+            coordinate = np.array(coordinate)
+        assert isinstance(coordinate, np.ndarray)
+
         # Fetch the top left corner.
         x0, y0 = self._coordinate_of_origin_pixel
 
-        # Unpack the coordinate
-        x, y = coordinate
+        # Aim at handling both single coordinates stored in a 1d array as well as
+        # multiple coordinates stored in a 2d array. Convert to the more general
+        # case.
+        original_shape = coordinate.shape
+        coordinate = np.atleast_2d(coordinate)
 
-        # Invert pixelToCoordinate, and apply floor to obtain an integer
-        pixel_x: int = math.floor((x - x0) * self._num_pixels_width / self._width)
-        pixel_y: int = math.floor(-(y - y0) * self._num_pixels_height / self._height)
+        # Initialize coordinates
+        pixel = np.empty_like(coordinate, dtype=int)
 
-        # Return final result
-        return pixel_y, pixel_x
+        # Invert pixelToCoordinate. Again combine two operations. 1. Convert from
+        # (row,col) to (x,y) format and scale correctly, to obtain the physical
+        # coordinates with correct units. Use floor to indicate which pixel is
+        # marked by the coordinate.
+        pixel[:, 0] = np.floor(
+            (y0 - coordinate[:, 1]) * self._num_pixels_height / self._height
+        )
+        pixel[:, 1] = np.floor(
+            (coordinate[:, 0] - x0) * self._num_pixels_width / self._width
+        )
+
+        # Return in same format as the input
+        return pixel.reshape(original_shape).astype(int)

--- a/src/daria/image/patches.py
+++ b/src/daria/image/patches.py
@@ -18,7 +18,7 @@ class Patches:
         num_patches_y (int) = number of patches in the vertical direction
         images (np.ndarray)= array of patches of the original image
 
-    NOTE: A Cartesian ordering is used to refer to specific patches, i.e.,
+    NOTE: A Cartesian indexing is used to refer to specific patches, i.e.,
         The lower left patch will have the patch coordinate (0,0), while the
         top right patch will have the patch coordinate
         (num_patches_x-1, num_patches_y-1).
@@ -27,7 +27,7 @@ class Patches:
         assemble (da.Image): reassembles the patches to a new image
     """
 
-    def __init__(self, im: da.Image, *args, **kwargs) -> None:
+    def __init__(self, img: da.Image, *args, **kwargs) -> None:
         """
         Constructor for Patches class.
 
@@ -44,7 +44,7 @@ class Patches:
         """
 
         # Instance of base image and relative_overlap
-        self.baseImg = im
+        self.baseImg = img
         self.relative_overlap = kwargs.pop("rel_overlap", 0.0)
 
         # Define number of patches in each direction
@@ -61,37 +61,36 @@ class Patches:
 
         # Define base width and height of each patch (without overlap)...
         # ... in metric units
-        patch_width = self.baseImg.width / self.num_patches_x
-        patch_height = self.baseImg.height / self.num_patches_y
+        patch_width_metric = self.baseImg.width / self.num_patches_x
+        patch_height_metric = self.baseImg.height / self.num_patches_y
         # ... and in numbers of pixles
-        patch_pixels_width = self.baseImg.coordinatesystem.lengthToPixels(
-            patch_width, "x"
+        patch_width_pixels = self.baseImg.coordinatesystem.lengthToPixels(
+            patch_width_metric, "x"
         )
-        patch_pixels_height = self.baseImg.coordinatesystem.lengthToPixels(
-            patch_height, "y"
+        patch_height_pixels = self.baseImg.coordinatesystem.lengthToPixels(
+            patch_height_metric, "y"
         )
 
         # Determine the overal in metric lengths
-        overlap_width = self.relative_overlap * patch_width
-        overlap_height = self.relative_overlap * patch_height
-        # TODO rename and put pixels to the back
+        overlap_width_metric = self.relative_overlap * patch_width_metric
+        overlap_height_metric = self.relative_overlap * patch_height_metric
 
         # Convert the overlap from metric to numbers of pixels
-        overlap_pixels_width = self.baseImg.coordinatesystem.lengthToPixels(
-            overlap_width, "x"
+        overlap_width_pixels = self.baseImg.coordinatesystem.lengthToPixels(
+            overlap_width_metric, "x"
         )
-        overlap_pixels_height = self.baseImg.coordinatesystem.lengthToPixels(
-            overlap_height, "y"
+        overlap_height_pixels = self.baseImg.coordinatesystem.lengthToPixels(
+            overlap_height_metric, "y"
         )
 
         # Some abbreviation for better overview
         nh = self.baseImg.num_pixels_height
-        pw = patch_pixels_width
-        ph = patch_pixels_height
-        ow = overlap_pixels_width
-        oh = overlap_pixels_height
-        cw = ceil(overlap_pixels_width / 2)
-        ch = ceil(overlap_pixels_height / 2)
+        pw = patch_width_pixels
+        ph = patch_height_pixels
+        ow = overlap_width_pixels
+        oh = overlap_height_pixels
+        cw = ceil(overlap_width_pixels / 2)
+        ch = ceil(overlap_height_pixels / 2)
         off_w = 0 if cw == ow / 2.0 else 1
         off_h = 0 if ch == oh / 2.0 else 1
 
@@ -105,10 +104,11 @@ class Patches:
         self.off_w = off_w
         self.off_h = off_h
 
-        # TODO if this works, change the convention of numbering of patches. and use the
-        # same as for images.
-
         # Define pixel-based ROIs - with overlap
+        # NOTE: While patches use the Cartesian indexing, the ROIs address
+        # images with conventional matrix indexing, i.e., (x,y) vs (row,col).
+        # Thus, the standard conversion has to be applied: Flip arguments and flip
+        # the orientation of the vertical component.
         self.rois: list[list[tuple]] = [
             [
                 (
@@ -120,15 +120,12 @@ class Patches:
             for i in range(self.num_patches_x)
         ]
 
-        # Define relative pixel-based ROIs corresponding to the area - without overlap
+        # Define relative pixel-based ROIs corresponding to the area - without overlap.
         self.relative_rois_without_overlap: list[list[tuple]] = [
             [
                 (
-                    slice(
-                        0 if j == self.num_patches_y - 1 else oh,
-                        ph if j == self.num_patches_y - 1 else ph + oh,
-                    ),
-                    slice(0 if i == 0 else ow, pw if i == 0 else pw + ow),
+                    slice(0, ph) if j == self.num_patches_y else slice(oh, ph + oh),
+                    slice(0, pw) if i == 0 else slice(ow, pw + ow),
                 )
                 for j in range(self.num_patches_y)
             ]
@@ -149,7 +146,12 @@ class Patches:
             [
                 [
                     self.baseImg.origo
-                    + np.array([(i + 0.5) * patch_width, (j + 0.5) * patch_height])
+                    + np.array(
+                        [
+                            (i + 0.5) * patch_width_metric,
+                            (j + 0.5) * patch_height_metric,
+                        ]
+                    )
                     for j in range(self.num_patches_y)
                 ]
                 for i in range(self.num_patches_x)
@@ -226,8 +228,8 @@ class Patches:
         )
 
         # Analogously, define the weighting in y-direction.
-        # NOTE: The weight has to be defined consistently with the conventional pixel ordering
-        # of images, i.e., the first pixel lies at the top.
+        # NOTE: The weight has to be defined consistently with the conventional matrix
+        # indexing of images, i.e., the first pixel lies at the top.
         self.weight_y = {}
 
         # Corresponding to the bottom patches
@@ -279,7 +281,7 @@ class Patches:
             i (int): patch coordinate in x-direction
             j (int): patch coordinate in y-direction
 
-        NOTE: The patch coordinates employ the Cartesian ordering.
+        NOTE: The patch coordinates employ the Cartesian indexing, i.e., (x,y).
 
         Returns:
             str: "left" or "right" if the patch is touching the left or right boundary
@@ -306,12 +308,26 @@ class Patches:
         return horizontal_position, vertical_position
 
     def __call__(self, i: int, j: int) -> np.ndarray:
-        """Return patch with patch coordinates (i,j)."""
+        """
+        Return patch with Cartesian patch coordinates (i,j).
+
+        Args:
+            i (int): x-coordinate of the patch
+            j (int): y-coordinate of the patch
+
+        Returns:
+            np.ndarray: image of the patch
+        """
         return self.images[i][j]
 
     def set_image(self, img: np.ndarray, i: int, j: int) -> None:
         """
         Update the image of a patch.
+
+        Args:
+            img (np.ndarray): image array
+            i (int): x-coordinate of the patch
+            j (int): y-coordinate of the patch
         """
         assert self.images[i][j].img.shape == img.shape
         self.images[i][j].img = img.copy()
@@ -329,7 +345,8 @@ class Patches:
         """
 
         # Initialize empty row of the final image. It will be used
-        # to assemble the patches row by row.
+        # to assemble the patches 'row' by 'row' (here row is not
+        # meant as for images, as patches use Cartesian coordinates).
         assembled_img = np.zeros(
             (0, *self.baseImg.img.shape[1:]), dtype=self.baseImg.img.dtype
         )
@@ -337,19 +354,21 @@ class Patches:
         # Create "image-strips" that are assembled by concatenation
         for j in range(self.num_patches_y):
 
-            # Initialize the row of the final image with the first patch image.
+            # Initialize the row with y coordinate j of the final image
+            # with the first patch image.
             rel_roi = self.relative_rois_without_overlap[0][j]
-            assembled_row_j = self.images[0][j].img[rel_roi]
+            assembled_y_j = self.images[0][j].img[rel_roi]
 
-            # And assemble the remainder of the row by concatenation.
+            # And assemble the remainder of the row by concatenation
+            # over the patches in x-direction with same y coordinate (=j).
             for i in range(1, self.num_patches_x):
                 rel_roi = self.relative_rois_without_overlap[i][j]
-                assembled_row_j = np.hstack(
-                    (assembled_row_j, self.images[i][j].img[rel_roi])
+                assembled_y_j = np.hstack(
+                    (assembled_y_j, self.images[i][j].img[rel_roi])
                 )
 
             # Concatenate the row and the current image
-            assembled_img = np.vstack((assembled_row_j, assembled_img))
+            assembled_img = np.vstack((assembled_y_j, assembled_img))
 
         # Make sure that the resulting image has the same resolution
         assert assembled_img.shape == self.baseImg.img.shape
@@ -398,14 +417,15 @@ class Patches:
         # Loop over patches
         for j in range(self.num_patches_y):
 
-            # Allocate memory for row j
+            # Allocate memory for row  with y-coordinate j.
             shape = [self.images[0][j].num_pixels_height, *self.baseImg.img.shape[1:]]
-            assembled_row_j = np.zeros(tuple(shape), dtype=float)
+            assembled_y_j = np.zeros(tuple(shape), dtype=float)
 
-            # Assemble row j by suitable weighted combination of the patches in row j
+            # Assemble the row with y-coordinate j by a suitable weighted combination
+            # of the patches in row j
             for i in range(self.num_patches_x):
 
-                # Determine active pixel range
+                # Determine the active pixel range
                 roi = self.rois[i][j]
                 roi_x = roi[1]
 
@@ -418,7 +438,7 @@ class Patches:
                 weight_i_j = weight_i_j.reshape(1, np.size(weight_i_j), 1)
 
                 # Add weighted patch at the active pixel range
-                assembled_row_j[:, roi_x] += np.multiply(img_i_j, weight_i_j)
+                assembled_y_j[:, roi_x] += np.multiply(img_i_j, weight_i_j)
 
             # Anologous procedure, but now on row-level and not single-patch level.
 
@@ -432,7 +452,7 @@ class Patches:
             weight_j = weight_j.reshape(np.size(weight_j), 1, 1)
 
             # Add weighted row at the active pixel range
-            assembled_img[roi_y, :] += np.multiply(assembled_row_j, weight_j)
+            assembled_img[roi_y, :] += np.multiply(assembled_y_j, weight_j)
 
         # Make sure the newly assembled image is compatible with the original base image
         assert assembled_img.shape == self.baseImg.img.shape

--- a/src/daria/image/subregions.py
+++ b/src/daria/image/subregions.py
@@ -1,7 +1,11 @@
-from daria import Image
+import numpy as np
+
+import daria
 
 
-def extractROI(img: Image, x: list, y: list, return_roi: bool = False) -> Image:
+def extractROI(
+    img: daria.Image, x: list, y: list, return_roi: bool = False
+) -> daria.Image:
     """Extracts region of interest based on physical coordinates.
 
     Arguments:
@@ -11,22 +15,24 @@ def extractROI(img: Image, x: list, y: list, return_roi: bool = False) -> Image:
             points in metric units.
 
     Returns:
-        Image: image object restricted to the ROI.
+        daria.Image: image object restricted to the ROI.
     """
 
     # Assume that x and y are in increasing order.
     assert x[0] < x[1] and y[0] < y[1]
 
     # Convert metric units to number of pixels, and define top-left and bottom-right
-    # corners of the roi, towards addressing the image with conventional ordering
+    # corners of the roi, towards addressing the image with matrix indexing
     # of x and y coordinates.
-    top_left_corner = img.coordinatesystem.coordinateToPixel((x[0], y[1]))
-    bottom_right_corner = img.coordinatesystem.coordinateToPixel((x[1], y[0]))
+    top_left_coordinate = [x[0], y[1]]
+    bottom_right_coordinate = [x[1], y[0]]
+    top_left_pixel = img.coordinatesystem.coordinateToPixel(top_left_coordinate)
+    bottom_right_pixel = img.coordinatesystem.coordinateToPixel(bottom_right_coordinate)
 
-    # Define the ROI
+    # Define the ROI in terms of pixels, using matrix indexing, i.e., the (row,col) format
     roi = (
-        slice(top_left_corner[0], bottom_right_corner[0]),
-        slice(top_left_corner[1], bottom_right_corner[1]),
+        slice(top_left_pixel[0], bottom_right_pixel[0]),
+        slice(top_left_pixel[1], bottom_right_pixel[1]),
     )
 
     # Define metadata (all quantities in metric units)
@@ -36,26 +42,29 @@ def extractROI(img: Image, x: list, y: list, return_roi: bool = False) -> Image:
 
     # Construct and return image corresponding to ROI
     if return_roi:
-        return Image(img=img.img[roi], origo=origo, width=width, height=height), roi
+        return (
+            daria.Image(img=img.img[roi], origo=origo, width=width, height=height),
+            roi,
+        )
     else:
-        return Image(img=img.img[roi], origo=origo, width=width, height=height)
+        return daria.Image(img=img.img[roi], origo=origo, width=width, height=height)
 
 
-def extractROIPixel(img: Image, roi: tuple) -> Image:
+def extractROIPixel(img: daria.Image, roi: tuple) -> daria.Image:
     """Extracts region of interest based on pixel info.
 
     Arguments:
         roi (tuple of slices): to be used straight away to extract a region of interest;
-            using the conventional pixel ordering
+            using the conventional matrix indexing, i.e., (row,col).
 
     Returns:
-        Image: image object restricted to the ROI.
+        daria.Image: image object restricted to the ROI.
     """
-    # Define metadata; Note that img.origo uses a Cartesian ordering, while roi
-    # uses the conventional pixel ordering
-    origo = [img.origo[0] + roi[1].start * img.dx, img.origo[1] + roi[0].stop * img.dy]
-    width = (roi[1].stop - roi[1].start) * img.dx
+    # Define metadata; Note that img.origo uses a Cartesian indexing, while the
+    # roi uses the conventional matrix indexing
+    origo = img.origo + np.array([roi[1].start * img.dx, roi[0].stop * img.dy])
     height = (roi[0].stop - roi[0].start) * img.dy
+    width = (roi[1].stop - roi[1].start) * img.dx
 
     # Construct and return image corresponding to ROI
-    return Image(img=img.img[roi], origo=origo, width=width, height=height)
+    return daria.Image(img=img.img[roi], origo=origo, width=width, height=height)

--- a/src/daria/utils/conversions.py
+++ b/src/daria/utils/conversions.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-from typing import Union
-
 import numpy as np
-
-import daria as da
 
 
 def cv2ToSkimage(img: np.ndarray) -> np.ndarray:
@@ -20,95 +16,58 @@ def cv2ToSkimage(img: np.ndarray) -> np.ndarray:
     return img[:, :, ::-1]
 
 
-def standardToPhysicalPixelOrdering(img: np.ndarray) -> np.ndarray:
-    """Reordering of pixels finally using a physical pixel ordering, starting from a
-    standard one.
+def matrixToCartesianIndexing(img: np.ndarray) -> np.ndarray:
+    """
+    Reordering data indexing converting from (row,col) to (x,y) indexing.
 
-    The standard ordering of pixels for images is that the top left
-    corner is the (0,0) pixel. With increasing x- and y-pixels, one
-    moves towards the lower right corner. In addition, the first and
-    second components correspond to the y and x pixels, respectively.
-    This is inconsistent with the physical coordinate system,
-    considering a standard photograph.
-
-    Therefore, we introduce the term 'physical ordering' which identifies
-    the lower left corner as (0,0) pixel. And with increasing x-
-    and y-pixels, one moves towards the top right corner. In addition,
-    first and second components correspond to x and y.
+    The conventional matrix indexing uses the (row, col) format, such
+    that the top left corner is the (0,0) pixel. On the other hand,
+    Cartesian indexing uses the (x,y) order and thereby identifies
+    the lower left corner by (0,0). This routine is in particular useful
+    when communicating image data to conventional simulators, which use
+    the Cartesian indexing.
 
     Arguments:
-        np.ndarray: image array with standard pixel ordering
+        np.ndarray: image array with matrix indexing
 
     Returns:
-        np.ndarray: image array with physical pixel ordering
+        np.ndarray: image array with Cartesian indexing
     """
     if len(img.shape) > 3:
-        raise NotImplementedError("Pixel conversion only implemented for 2d images.")
+        raise NotImplementedError("Format conversion only implemented for 2d images.")
 
-    # Reorder the y-pixels, corresponding to the first component
-    img = np.flip(img, 0)
+    # Two operations are require: Swapping axis and flipping the vertical axis.
 
-    # Flip first and second component
+    # Exchange first and second component, to change from (row,col) to (x,y) format.
     img = np.swapaxes(img, 0, 1)
+
+    # Flip the orientation of the second axis, such that later y=0 is located at the bottom.
+    img = np.flip(img, 1)
 
     return img
 
 
-def physicalToStandardPixelOrdering(img: np.ndarray) -> np.ndarray:
-    """Reordering of pixels finally using a standard pixel ordering, starting from a
-    physical one.
+def cartesianToMatrixIndexing(img: np.ndarray) -> np.ndarray:
+    """
+    Reordering data indexing, converting from (x,y) to (row,col) indexing.
 
-    Inverse to standardToPhysicalPixelOrdering. It is the same operations, but in
-    reverse order.
+    Inverse to matrixToCartesianIndexing.
 
     Arguments:
-        np.ndarray: image array with physical pixel ordering
+        np.ndarray: image array with Cartesian indexing
 
     Returns:
-        np.ndarray: image array with physical pixel ordering
+        np.ndarray: image array with matrix indexing
     """
     if len(img.shape) > 3:
-        raise NotImplementedError("Pixel conversion only implemented for 2d images.")
+        raise NotImplementedError("Format conversion only implemented for 2d images.")
 
-    # Flip first and second component
+    # Two operations are require: Swapping axis and flipping the vertical axis.
+
+    # Flip the orientation of the second axis, such that later row=0 is located at the top.
+    img = np.flip(img, 1)
+
+    # Exchange first and second component, to change from (x,y) to (row,col) format.
     img = np.swapaxes(img, 0, 1)
 
-    # Reorder the y-pixels, corresponding to the first component
-    img = np.flip(img, 0)
-
     return img
-
-
-def standardToPhysicalPixel(
-    img: da.Image, pixel: Union[tuple[int], list[int]]
-) -> tuple[int]:
-    """Translate a standard to a physical pixel.
-
-    The conversion is based on the width and height of the corresponding image.
-
-    Arguments:
-        img (Image): image object
-        pixel (list of int): standard pixel
-
-    Returns:
-        list of int: physical pixel
-    """
-    # TODO
-    pass
-
-
-def physicalToStandardPixel(
-    img: da.Image, pixel: Union[tuple[int], Union[tuple[int], list[int]]]
-) -> tuple[int]:
-    """Translate a physica pixel to a standard pixel.
-
-    Inversie of standardToPhysicalPixel.
-
-    Arguments:
-        img (Image): image object
-        pixel (list of int): physical pixel
-
-    Returns:
-        list of int: standard pixel
-    """
-    return img.shape[1] - pixel[1], pixel[0]

--- a/src/daria/utils/features.py
+++ b/src/daria/utils/features.py
@@ -30,7 +30,8 @@ class FeatureDetection:
 
         Returns:
             tuple: tuple of
-                kps: keypoints of the features
+                kps: keypoints of the features; note keypoints come in (col, row),
+                    i.e., reversed matrix indexing
                 np.ndarray: descriptors of the features
             bool: flag indicating whether features have been found
         """
@@ -72,10 +73,9 @@ class FeatureDetection:
                 which could e.g. be used for plotting
 
         Returns:
-            tuple: tuple of
-                np.ndarray: homography matching the features
-                bool: flag indicating whether procedure has been successful
-                matches (optional): matches between features # TODO type
+            np.ndarray: homography matrix matching the features
+            bool: flag indicating whether procedure has been successful
+            matches (optional): matches between features # TODO type
         """
         # Unpack features (keypoints and descriptors)
         kps_src, descs_src = features_src
@@ -109,7 +109,7 @@ class FeatureDetection:
         # Consider the top matches
         matches = matches[:keep]
 
-        # Allocate memory for the keypoints (x, y)-coordinates from the
+        # Allocate memory for the keypoints (col, row)-coordinates from the
         # top matches.
         pts_src = np.zeros((len(matches), 2), dtype="float")
         pts_dst = np.zeros((len(matches), 2), dtype="float")


### PR DESCRIPTION
Following the often used terms 'Cartesian indexing' and 'matrix indexing', we also include their use in daria. The first addresses xy indexing, e.g., for coordinates using a (x,y) format. The latter addresses pixels in images, using a (row,col). Since cv2 often uses a (col,row) format, we also introduce the term 'reverse matrix indexing'. From now on, we aim at using this terminology.

In addition, in this overhaul, many (almost all) pairs of two numbers are encoded as numpy arrays. Still some routines accept lists as input to ease in the initializiation of some classes. But these get converted to arrays under the hood. Arrays are often easier to handle in computations and will therefore be prioritized in many routines.