### PR TITLE
Minor maintanence - keeping shapes of 3-tensors after applying cv2 functions

### DIFF
--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import numpy as np
 from scipy.ndimage import map_coordinates
 
+
 # TODO: Add an automatic way (using e.g, gradient decent) to choose the parameters.
 # OR determine manual tuning rules.
 def simple_curvature_correction(img: np.ndarray, **kwargs) -> np.ndarray:

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 from scipy.ndimage import map_coordinates
 
-
 # TODO: Add an automatic way (using e.g, gradient decent) to choose the parameters.
 # OR determine manual tuning rules.
 def simple_curvature_correction(img: np.ndarray, **kwargs) -> np.ndarray:
@@ -93,12 +92,12 @@ def simple_curvature_correction(img: np.ndarray, **kwargs) -> np.ndarray:
     out_grid = np.array([Ymod.ravel(), Xmod.ravel()])
 
     # Define the shape corrected image.
-    img_mod = np.zeros_like(img, dtype=np.uint8)
+    img_mod = np.zeros_like(img, dtype=img.dtype)
 
     # Do interpolate original image on the new grid
     for i in range(img.shape[2]):
         in_data = img[:, :, i]
         im_array = map_coordinates(in_data, out_grid, order=interpolation_order)
-        img_mod[:, :, i] = im_array.reshape(img.shape[:2]).astype(np.uint8)
+        img_mod[:, :, i] = im_array.reshape(img.shape[:2]).astype(img.dtype)
 
     return img_mod

--- a/src/daria/corrections/shape/quadROI.py
+++ b/src/daria/corrections/shape/quadROI.py
@@ -68,9 +68,12 @@ def extract_quadrilateral_ROI(img_src: np.ndarray, **kwargs) -> np.ndarray:
         pts_src.astype(np.float32), pts_dst.astype(np.float32)
     )
 
-    # Warp source image
-    img_dst = cv2.warpPerspective(
-        img_src, P, (target_width, target_height), flags=cv2.INTER_LINEAR
+    # Warp source image. Warping may convert a 3-tensor to a 2-tensor.
+    # Force to use a 3-tensor structure.
+    img_dst = np.atleast_3d(
+        cv2.warpPerspective(
+            img_src, P, (target_width, target_height), flags=cv2.INTER_LINEAR
+        )
     )
 
     return img_dst

--- a/src/daria/utils/conversions.py
+++ b/src/daria/utils/conversions.py
@@ -33,9 +33,6 @@ def matrixToCartesianIndexing(img: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: image array with Cartesian indexing
     """
-    if len(img.shape) > 3:
-        raise NotImplementedError("Format conversion only implemented for 2d images.")
-
     # Two operations are require: Swapping axis and flipping the vertical axis.
 
     # Exchange first and second component, to change from (row,col) to (x,y) format.
@@ -59,9 +56,6 @@ def cartesianToMatrixIndexing(img: np.ndarray) -> np.ndarray:
     Returns:
         np.ndarray: image array with matrix indexing
     """
-    if len(img.shape) > 3:
-        raise NotImplementedError("Format conversion only implemented for 2d images.")
-
     # Two operations are require: Swapping axis and flipping the vertical axis.
 
     # Flip the orientation of the second axis, such that later row=0 is located at the top.

--- a/src/daria/utils/resolution.py
+++ b/src/daria/utils/resolution.py
@@ -20,4 +20,5 @@ def resize(img: np.ndarray, scale_percent: float = 100) -> np.ndarray:
     width = int(img.shape[1] * scale_percent / 100)
     height = int(img.shape[0] * scale_percent / 100)
     dim = (width, height)
-    return cv2.resize(img, dim, interpolation=cv2.INTER_AREA)
+    # Omit converting 3-tensors to 2-tensors.
+    return np.atleast_3d(cv2.resize(img, dim, interpolation=cv2.INTER_AREA))


### PR DESCRIPTION
Main changes are based on the observation that cv2 converts 3-tensors with the shape (row,col,1) to 2-tensors with shape (row,col), when applying some function. This is not always wished. Instead, as we use libraries which do change the shape and some which not, we maybe should always try to stick to the input shape, if not explicitly requested differently. 