### PR TITLE
Retrieve metadata from jpg files using PIL

### DIFF
--- a/examples/co2_and_tracer_analysis.py
+++ b/examples/co2_and_tracer_analysis.py
@@ -3,6 +3,8 @@ Example script for simple image analysis. By comparison of images
 of the same well test, a tracer concentration can be determined.
 """
 
+from pathlib import Path
+
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
@@ -26,7 +28,7 @@ def preprocessing(img: np.ndarray) -> np.ndarray:
     # (which can be created the workflow presented in the Jupyter notebook
     # examples/notebooks/curvature_correction_walkthrough.ipynb).
     curvature_correction = daria.CurvatureCorrection(
-        config_source="./images/config.json", width=2.8, height=1.5
+        config_source=Path("./images/config.json"), width=2.8, height=1.5
     )
 
     # Apply curvature correction.

--- a/examples/co2_and_tracer_analysis.py
+++ b/examples/co2_and_tracer_analysis.py
@@ -3,8 +3,6 @@ Example script for simple image analysis. By comparison of images
 of the same well test, a tracer concentration can be determined.
 """
 
-from pathlib import Path
-
 import cv2
 import matplotlib.pyplot as plt
 import numpy as np
@@ -28,7 +26,7 @@ def preprocessing(img: np.ndarray) -> np.ndarray:
     # (which can be created the workflow presented in the Jupyter notebook
     # examples/notebooks/curvature_correction_walkthrough.ipynb).
     curvature_correction = daria.CurvatureCorrection(
-        config_source=Path("./images/config.json"), width=2.8, height=1.5
+        config_source="./images/config.json", width=2.8, height=1.5
     )
 
     # Apply curvature correction.
@@ -39,8 +37,8 @@ def preprocessing(img: np.ndarray) -> np.ndarray:
 
     # Apply color correction - need to specify a crude ROI containing the color checker.
     roi_cc = (slice(0, 600), slice(0, 700))
-    colorcorrection = daria.ColorCorrection()
-    img = colorcorrection.adjust(img, roi_cc)
+    color_correction = daria.ColorCorrection()
+    img = color_correction(img, roi_cc)
 
     return img
 

--- a/examples/co2_and_tracer_analysis.py
+++ b/examples/co2_and_tracer_analysis.py
@@ -38,7 +38,7 @@ def preprocessing(img: np.ndarray) -> np.ndarray:
     # Apply color correction - need to specify a crude ROI containing the color checker.
     roi_cc = (slice(0, 600), slice(0, 700))
     color_correction = daria.ColorCorrection()
-    img = color_correction(img, roi_cc)
+    img = color_correction.adjust(img, roi_cc)
 
     return img
 

--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -16,6 +16,9 @@ import numpy as np
 
 import daria as da
 
+from PIL import Image as PIL_Image
+from datetime import datetime
+
 
 class Image:
     """Base image class.
@@ -55,7 +58,11 @@ class Image:
         dim: int = 2,
         read_metadata_from_file: bool = False,
         metadata_path: Optional[str] = None,
-        # TODO USE **kwargs in contructor
+        # TODO Have to rethink the use of parameters, and possibly switch to
+        # a config file instead, that is shared among a full suite of images.
+        # It should contain information on the correction routines, necessary.
+        # It should include physical information: width, height
+        # It should include the format of timestamps included in the exifdata
     ) -> None:
         """Constructor of Image object.
 
@@ -78,9 +85,19 @@ class Image:
         # Fetch image
         if isinstance(img, np.ndarray):
             self.img = img
+
+            # Come up with default metadata
             self.name = "Unnamed image"
+            self.timestamp = None
+
         elif isinstance(img, str):
-            self.img = cv2.imread(str(Path(img)))
+            pil_img = PIL_Image.open(img)
+            self.img = np.array(pil_img)
+
+            # Read exif metadata
+            self.exif = pil_img.getexif()
+            self.timestamp: datetime = datetime.strptime(exif.get(306), "%Y:%m:%d %H:%M:%S")
+
             self.imgpath = img
             self.name = img
         else:
@@ -175,6 +192,8 @@ class Image:
             metadata_path (str): path to metadata (only folders); the metadata file
                 has the same name as the image (and a .txt ending)
         """
+        # TODO need to make sure that image is in BGR format
+
         # Write image, using the conventional matrix indexing
         cv2.imwrite(str(Path(path + name + file_format)), self.img)
         print("Image saved as: " + str(Path(path + name + file_format)))


### PR DESCRIPTION
Use PIL to open images in `Image`. PIL allows also reading metadata as time stamp. This information can be very useful when considering time series.