### PR TITLE
Hotfix: Show the image in curvature correction.

### DIFF
--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -154,6 +154,7 @@ class CurvatureCorrection:
         Shows the current image using matplotlib.pyplot
         """
         plt.imshow(cv2.cvtColor(self.temporary_image, cv2.COLOR_BGR2RGB))
+        plt.show()
 
     @property
     def temporary_image(self):


### PR DESCRIPTION
The method `show_image` was lacking a `plt.show()` to in fact show the image.