### PR TITLE
Hotfix: Plot image in RGB in curvature correction.

### DIFF
--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -12,7 +12,6 @@ import math
 from pathlib import Path
 from typing import Optional, Union
 
-import cv2
 import matplotlib.pyplot as plt
 import numpy as np
 import skimage

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -153,7 +153,7 @@ class CurvatureCorrection:
         """
         Shows the current image using matplotlib.pyplot
         """
-        plt.imshow(cv2.cvtColor(self.temporary_image, cv2.COLOR_BGR2RGB))
+        plt.imshow(self.temporary_image)
         plt.show()
 
     @property


### PR DESCRIPTION
Images read with PIL are coded in RGB. The conversion between BGR and RGB in the plotting function of the curvature correction is obsolete and has been removed. Images are now plotted in the expected color spectrum.