### PR TITLE
Add timestamp to metadata

### DIFF
--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -168,7 +168,7 @@ class ConcentrationAnalysis:
         # Convert from signal to concentration
         concentration = np.clip(self.scaling * processed_signal + self.offset, 0, 1)
 
-        return daria.Image(concentration, self.base.metadata)
+        return daria.Image(concentration, img.metadata)
 
     # ! ---- Pre- and post-processing methods
 

--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -120,7 +120,8 @@ class Image:
 
             # Come up with default metadata
             self.name = "Unnamed image"
-            self.timestamp = None
+            if "timestamp" not in self.metadata:
+                self.metadata["timestamp"] = None
 
             if no_colorspace_given:
                 warn("Please provide a color space. Now it is assumed to be BGR.")
@@ -135,11 +136,11 @@ class Image:
             # Read exif metadata
             self.exif = pil_img.getexif()
             if self.exif.get(306) is not None:
-                self.timestamp: datetime = datetime.strptime(
+                self.metadata["timestamp"] = datetime.strptime(
                     self.exif.get(306), "%Y:%m:%d %H:%M:%S"
                 )
             else:
-                self.timestamp = None
+                self.metadata["timestamp"] = None
 
             self.imgpath = img
             self.name = img
@@ -193,6 +194,10 @@ class Image:
     @property
     def colorspace(self) -> str:
         return self.metadata["color_space"]
+
+    @property
+    def timestamp(self) -> datetime.datetime:
+        return self.metadata["timestamp"]
 
     def write(
         self,


### PR DESCRIPTION
So far timestamp has been an attribute of daria Images. This PR makes it part of `metadata`. Access is granted via a `@property` decorator such that nothing else changes in further use.