### PR TITLE
Enforces np.int64 also on precompute_transform_coordinates

### DIFF
--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -488,8 +488,8 @@ class CurvatureCorrection:
         Ny, Nx = img.shape[:2]
 
         # Define coordinates
-        x = np.arange(Nx)
-        y = np.arange(Ny)
+        x = np.arange(Nx, dtype=np.int64)
+        y = np.arange(Ny, dtype=np.int64)
 
         # Construct associated meshgrid with Cartesian indexing
         X, Y = np.meshgrid(x, y)


### PR DESCRIPTION
Im just merging this so that Benyamine can work whenever he wants to (It is a two-line fix that we can revert if it causes trouble but I doubt it will be necessary)