### PR TITLE
Fix of several issues in CurvatureCorrection

### DIFF
--- a/examples/images/config.json
+++ b/examples/images/config.json
@@ -31,13 +31,13 @@
     "bulge": {
         "horizontal_bulge": -0.0,
         "horizontal_center_offset": 0,
-        "vertical_bulge": -2.5945990825497644e-08,
-        "vertical_center_offset": -33
+        "vertical_bulge": -2.7297344514325645e-08,
+        "vertical_center_offset": -31
     },
     "stretch": {
         "horizontal_stretch": -1.3307656210674836e-08,
         "horizontal_center_offset": -114,
         "vertical_stretch": -0.0,
-        "vertical_center_offset": 126
+        "vertical_center_offset": 168
     }
 }

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -87,7 +87,6 @@ class CurvatureCorrection:
                 )
             self.current_image = np.copy(self.reference_image)
             self.dtype = self.current_image.dtype
-            self.Ny, self.Nx = self.reference_image.shape[:2]
             self.in_meters = kwargs.pop("in_meters", True)
             self.width = kwargs.pop("width", 1.0)
             self.height = kwargs.pop("height", 1.0)
@@ -309,7 +308,7 @@ class CurvatureCorrection:
         bottom = kwargs.pop("bottom", 0)
 
         if img is None:
-            Ny, Nx = self.Ny, self.Nx
+            Ny, Nx = self.current_image.shape[:2]
         else:
             Ny, Nx = img.shape[:2]
 
@@ -363,7 +362,7 @@ class CurvatureCorrection:
         """
 
         if img is None:
-            Ny, Nx = self.Ny, self.Nx
+            Ny, Nx = self.current_image.shape[:2]
         else:
             Ny, Nx = img.shape[:2]
 

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -453,8 +453,8 @@ class CurvatureCorrection:
         Ny, Nx = img.shape[:2]
 
         # Define coordinates
-        x = np.arange(Nx, dtype=np.int64)
-        y = np.arange(Ny, dtype=np.int64)
+        x = np.arange(Nx, dtype=np.float32)
+        y = np.arange(Ny, dtype=np.float32)
 
         # Construct associated meshgrid with Cartesian indexing
         X, Y = np.meshgrid(x, y)
@@ -488,8 +488,8 @@ class CurvatureCorrection:
         Ny, Nx = img.shape[:2]
 
         # Define coordinates
-        x = np.arange(Nx, dtype=np.int64)
-        y = np.arange(Ny, dtype=np.int64)
+        x = np.arange(Nx, dtype=np.float32)
+        y = np.arange(Ny, dtype=np.float32)
 
         # Construct associated meshgrid with Cartesian indexing
         X, Y = np.meshgrid(x, y)

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -630,7 +630,9 @@ class CurvatureCorrection:
         Returns:
             np.ndarray: transformed image
         """
-        # Initialize the corrected image.
+        # Initialize the corrected image. To unify code, transform to 3d arrays and
+        # transform back in the end if needed.
+        img = np.atleast_3d(img)
         corrected_img = np.zeros((*shape, img.shape[2]), dtype=img.dtype)
 
         # Detemine the corrected image using interpolation based on the transformed
@@ -645,4 +647,4 @@ class CurvatureCorrection:
             # Convert to correct shape and data type
             corrected_img[:, :, i] = im_array_as_vector.reshape(shape).astype(img.dtype)
 
-        return corrected_img
+        return np.squeeze(corrected_img)

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -496,8 +496,7 @@ class CurvatureCorrection:
         # Define the current pixel mesh before any transformation
         Ny, Nx = img.shape[:2]
         X, Y = np.meshgrid(
-            np.arange(Nx, dtype=np.float32),
-            np.arange(Ny, dtype=np.float32)
+            np.arange(Nx, dtype=np.float32), np.arange(Ny, dtype=np.float32)
         )
 
         # Store references of the pixel coordinates in dict to easily iterate over both
@@ -513,9 +512,13 @@ class CurvatureCorrection:
             if "crop" in self.config:
                 pixels = da.extract_quadrilateral_ROI(pixels, **self.config["crop"])
             if "bulge" in self.config:
-                pixels = self.simple_curvature_correction(pixels, **self.config["bulge"])
+                pixels = self.simple_curvature_correction(
+                    pixels, **self.config["bulge"]
+                )
             if "stretch" in self.config:
-                pixels = self.simple_curvature_correction(pixels, **self.config["stretch"])
+                pixels = self.simple_curvature_correction(
+                    pixels, **self.config["stretch"]
+                )
 
             # Store the updated values
             coords[key] = pixels

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -285,12 +285,13 @@ class CurvatureCorrection:
 
     # ! ---- Auxiliary routines for computing tuning parameters in the correction.
 
-    def compute_bulge(self, **kwargs):
+    def compute_bulge(self, img: Optional[np.ndarray] = None, **kwargs):
         """
         Compute the bulge parameters depending on the maximum number of pixels
         that the image has been displaced on each side.
 
         Arguments:
+            img (np.ndarray, optional): image array, basis for the computation.
             kwargs (optional keyword arguments):
                 "left" (int): the maximum number of pixels that the image
                               has been displaced on the left side
@@ -307,33 +308,38 @@ class CurvatureCorrection:
         top = kwargs.pop("top", 0)
         bottom = kwargs.pop("bottom", 0)
 
+        if img is None:
+            Ny, Nx = self.Ny, self.Nx
+        else:
+            Ny, Nx = img.shape[:2]
+
         # Determine the center of the image
         if (left + right == 0) and (top + bottom == 0):
-            image_center = [round(self.Nx / 2), round(self.Ny / 2)]
+            image_center = [round(Nx / 2), round(Ny / 2)]
         elif left + right == 0:
-            image_center = [round(self.Nx / 2), round(self.Ny * (top) / (top + bottom))]
+            image_center = [round(Nx / 2), round(Ny * (top) / (top + bottom))]
         elif top + bottom == 0:
             image_center = [
-                round(self.Nx * (left) / (left + right)),
-                round(self.Ny / 2),
+                round(Nx * (left) / (left + right)),
+                round(Ny / 2),
             ]
         else:
             image_center = [
-                round(self.Nx * (left) / (left + right)),
-                round(self.Ny * (top) / (top + bottom)),
+                round(Nx * (left) / (left + right)),
+                round(Ny * (top) / (top + bottom)),
             ]
 
         # Determine the offset of the numerical center of the image
-        horizontal_bulge_center_offset = image_center[0] - round(self.Nx / 2)
-        vertical_bulge_center_offset = image_center[1] - round(self.Ny / 2)
+        horizontal_bulge_center_offset = image_center[0] - round(Nx / 2)
+        vertical_bulge_center_offset = image_center[1] - round(Ny / 2)
 
         # Determine the bulge tuning coefficients as explained in the daria notes
         # Assume here that the maximum impressions are applied at the image center
         horizontal_bulge = left / (
-            (left - image_center[0]) * image_center[1] * (self.Ny - image_center[1])
+            (left - image_center[0]) * image_center[1] * (Ny - image_center[1])
         )
         vertical_bulge = top / (
-            (top - image_center[1]) * image_center[0] * (self.Nx - image_center[0])
+            (top - image_center[1]) * image_center[0] * (Nx - image_center[0])
         )
 
         return (
@@ -343,34 +349,38 @@ class CurvatureCorrection:
             vertical_bulge_center_offset,
         )
 
-    def compute_stretch(self, **kwargs):
+    def compute_stretch(self, img: Optional[np.ndarray] = None, **kwargs):
         """
         Compute the stretch parameters depending on the stretch center,
         and a known translation.
 
         Arguments:
+            img (np.ndarray, optional): image array, basis for the computation.
             kwargs (optional keyword arguments):
                 "point_source" (list): point that has been translated.
                 "point_destination" (list): the ought to be position.
                 "stretch_center" (list): the stretch center.
         """
 
-        pt_src = kwargs.pop("point_source", [self.Ny, self.Nx])
-        pt_dst = kwargs.pop("point_destination", [self.Ny, self.Nx])
-        stretch_center = kwargs.pop(
-            "stretch_center", [round(self.Ny / 2), round(self.Nx / 2)]
-        )
+        if img is None:
+            Ny, Nx = self.Ny, self.Nx
+        else:
+            Ny, Nx = img.shape[:2]
+
+        pt_src = kwargs.pop("point_source", [Ny, Nx])
+        pt_dst = kwargs.pop("point_destination", [Ny, Nx])
+        stretch_center = kwargs.pop("stretch_center", [round(Ny / 2), round(Nx / 2)])
 
         # Update the offset to the center
-        horizontal_stretch_center_offset = stretch_center[0] - round(self.Nx / 2)
-        vertical_stretch_center_offset = stretch_center[1] - round(self.Ny / 2)
+        horizontal_stretch_center_offset = stretch_center[0] - round(Nx / 2)
+        vertical_stretch_center_offset = stretch_center[1] - round(Ny / 2)
 
         # Compute the tuning parameter as explained in the notes
         horizontal_stretch = -(pt_dst[0] - pt_src[0]) / (
-            (pt_src[0] - stretch_center[0]) * pt_src[0] * (self.Nx - pt_src[0])
+            (pt_src[0] - stretch_center[0]) * pt_src[0] * (Nx - pt_src[0])
         )
         vertical_stretch = -(pt_dst[1] - pt_src[1]) / (
-            (pt_src[1] - stretch_center[1]) * pt_src[1] * (self.Ny - pt_src[1])
+            (pt_src[1] - stretch_center[1]) * pt_src[1] * (Ny - pt_src[1])
         )
 
         return (


### PR DESCRIPTION
Several sloppy issues have been detected in CurvatureCorrection:
- Wrong precomputation of cached transformed pixels for fast evaluation of the curvature correction.
- Use of integers for pixel coordinates instead of floats, resulting in rounding when computing the correction. These values are not required to be of type integer as they will anyhow merely be used in the interpolation. When using integers, light discontinuities could be observed for transformations.
- Wrong use of reference dimensions in the computation of bulge and stretch factors.
- Lack of usability of curvature correction for grayscale images.

These issues have been solved in this PR, and tested by comparison with previous versions of the CurvatureCorrection. Note the name of the branch indicates loss of permformance. However, the final changes do not alter the performance of the code.

In addition (although not perfectly matching into this PR), argument lists have been extended to images for some auxiliary functions. 