### PR TITLE
Add drift correction

### DIFF
--- a/src/daria/__init__.py
+++ b/src/daria/__init__.py
@@ -22,6 +22,7 @@ from daria.corrections.shape.curvature import *
 from daria.corrections.shape.translation import *
 from daria.corrections.shape.piecewiseperspective import *
 from daria.corrections.shape.curvature import *
+from daria.corrections.shape.drift import *
 from daria.corrections.color.colorcorrection import *
 from daria.corrections.color.experimentalcolorcorrection import *
 from daria.analysis.translationanalysis import *

--- a/src/daria/corrections/shape/drift.py
+++ b/src/daria/corrections/shape/drift.py
@@ -1,0 +1,72 @@
+"""
+Module containing objects to align images with a baseline image,
+when restricted to a significant ROI. By this correction for drift
+is taking care of.
+"""
+
+from pathlib import Path
+from typing import Optional, Union
+
+import numpy as np
+from PIL import Image as PIL_Image
+
+import daria
+
+
+class DriftCorrection:
+    """
+    Class for drift correction of images wrt. a baseline image.
+    """
+
+    def __init__(
+        self,
+        base: Union[str, Path, np.ndarray, daria.Image],
+        roi: Optional[tuple] = None,
+    ) -> None:
+        """
+        Constructor for DriftCorrection.
+
+        Args:
+            base (str, Path, or array): path to baseline array, or array.
+            roi (2-tuple of slices): region of interest defining the
+                considered area for detecting features and aligning
+                images.
+
+        """
+
+        # Read baseline image
+        if isinstance(base, str) or isinstance(base, Path):
+            pil_base = PIL_Image.open(Path(base))
+            self.base = np.array(pil_base)
+        elif isinstance(base, np.ndarray):
+            self.base = np.copy(base)
+        elif isinstance(base, daria.Image):
+            self.base = np.copy(base.img)
+        else:
+            raise ValueError("Data type for baseline image not supported.")
+
+        # Cache roi
+        self.roi = roi
+
+        # Define a translation estimator
+        self.translation_estimator = daria.TranslationEstimator()
+
+    def __call__(self, img: np.ndarray, roi: Optional[tuple] = None) -> np.ndarray:
+        """
+        Main routine for aligning image with baseline image.
+
+        Args:
+            img (np.ndarray): input image, to be aligned.
+            roi (2-tuple of slices, optional): ROI to be applied to img; if None
+                the cached roi is used.
+
+        Returns:
+            np.ndarray: aligned image array.
+        """
+        # Define roi for source image. Let input argument be dominating over self.roi.
+        roi_src = self.roi if roi is None else roi
+
+        # Match image with baseline image
+        return self.translation_estimator.match_roi(
+            img_src=img, img_dst=self.base, roi_src=roi_src, roi_dst=self.roi
+        )

--- a/src/daria/corrections/shape/translation.py
+++ b/src/daria/corrections/shape/translation.py
@@ -36,8 +36,8 @@ class TranslationEstimator:
         self,
         img_src: np.ndarray,
         img_dst: np.ndarray,
-        roi_src: Optional[tuple],
-        roi_dst: Optional[tuple],
+        roi_src: Optional[tuple] = None,
+        roi_dst: Optional[tuple] = None,
         plot_matches: bool = False,
     ) -> tuple:
         """
@@ -101,8 +101,8 @@ class TranslationEstimator:
         self,
         img_src: Union[np.ndarray, daria.Image],
         img_dst: Union[np.ndarray, daria.Image],
-        roi_src: Optional[tuple],
-        roi_dst: Optional[tuple],
+        roi_src: Optional[tuple] = None,
+        roi_dst: Optional[tuple] = None,
         plot_matches: bool = False,
     ) -> Optional[np.ndarray]:
         """

--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -51,8 +51,9 @@ class Image:
         self,
         img: Union[np.ndarray, str, Path],
         metadata: Optional[dict] = None,
-        curvature_correction: Optional[da.CurvatureCorrection] = None,
+        drift_correction: Optional[da.DriftCorrection] = None,
         color_correction: Optional[da.ColorCorrection] = None,
+        curvature_correction: Optional[da.CurvatureCorrection] = None,
         **kwargs,
     ) -> None:
         """Constructor of Image object.
@@ -65,12 +66,13 @@ class Image:
         Arguments:
             img (Union[np.ndarray, str, Path]): image array with matrix indexing
             metadata (dict, Optional): metadata dictionary, default is None.
-            curvature_correction (daria.CurvatureCorrection, Optional):
-                Curvature correction object. Default is none, but should be included
-                if the image is to be curvature corrected at initialization
+            drift_correction (daria.DriftCorrection, optional): Drift correction object.
             color_correction (daria.ColorCorrection, Optional): Color correction object.
                 Default is none, but should be included if the image is to be color
                 corrected at initialization.
+            curvature_correction (daria.CurvatureCorrection, Optional):
+                Curvature correction object. Default is none, but should be included
+                if the image is to be curvature corrected at initialization
             kwargs (Optional arguments)
                 metadata_source (str): Path to a metadata json-file that provides
                     metadata such as physical width, height and origo of image
@@ -151,6 +153,9 @@ class Image:
             )
 
         # Apply corrections
+        if drift_correction is not None:
+            self.img = drift_correction(self.img)
+
         if color_correction is not None:
             self.toRGB()
             self.img = color_correction(self.img)

--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -66,7 +66,7 @@ class Image:
         Arguments:
             img (Union[np.ndarray, str, Path]): image array with matrix indexing
             metadata (dict, Optional): metadata dictionary, default is None.
-            drift_correction (daria.DriftCorrection, optional): Drift correction object.
+            drift_correction (daria.DriftCorrection, Optional): Drift correction object.
             color_correction (daria.ColorCorrection, Optional): Color correction object.
                 Default is none, but should be included if the image is to be color
                 corrected at initialization.


### PR DESCRIPTION
When analyzing a series of images, they ought be aligned wrt a fixed ROI. This has been so far possible with DarIA. However, it has not been integrated in the standard workflow when constructing for instance a `daria.Image`. Therefore, a new correction object has been introduced, automatizing the correction due to translation/drift (the latter name is suggested, as there exist already two translation objects in darIA).  

In addition, the correction has been integrated in `daria.Image` as well as in the `compaction_analysis.py` example, in which previously the `daria.TranslationEstimator` has been used to align images. 

Note: Aligning images is also relevant when working with concentration analysis, where images are directly compared.