### PR TITLE
Determine bounding box from coordinates

### DIFF
--- a/src/daria/__init__.py
+++ b/src/daria/__init__.py
@@ -18,6 +18,7 @@ from daria.mathematics.solvers import *
 from daria.mathematics.regularization import *
 from daria.utils.conversions import *
 from daria.utils.resolution import *
+from daria.utils.box import *
 from daria.corrections.shape.curvature import *
 from daria.corrections.shape.translation import *
 from daria.corrections.shape.piecewiseperspective import *

--- a/src/daria/corrections/color/colorcorrection.py
+++ b/src/daria/corrections/color/colorcorrection.py
@@ -78,7 +78,8 @@ class ColorCorrection:
 
         Args:
             roi (tuple of slices, np.ndarray, or None): ROI containing a colour checker,
-                provided either as intervals, corner points, or nothing.
+                provided either as intervals, corner points, or nothing. The recommended
+                choice is to provide an array of coordinates.
             verbosity (bool): flag controlling whether extracted ROIs of the colorchecker
                 as well as the extracted swatch colors are displayed. Useful for debugging.
             whitebalancing (bool): apply white balancing based on the third bottom left swatch

--- a/src/daria/corrections/shape/drift.py
+++ b/src/daria/corrections/shape/drift.py
@@ -21,17 +21,16 @@ class DriftCorrection:
     def __init__(
         self,
         base: Union[str, Path, np.ndarray, daria.Image],
-        roi: Optional[tuple] = None,
+        roi: Optional[Union[np.ndarray, tuple]] = None,
     ) -> None:
         """
         Constructor for DriftCorrection.
 
         Args:
             base (str, Path, or array): path to baseline array, or array.
-            roi (2-tuple of slices): region of interest defining the
-                considered area for detecting features and aligning
-                images.
-
+            roi (2-tuple of slices or array): region of interest defining
+                the considered area for detecting features and aligning
+                images. Either as tuple of ranges, or array of points.
         """
 
         # Read baseline image
@@ -46,7 +45,7 @@ class DriftCorrection:
             raise ValueError("Data type for baseline image not supported.")
 
         # Cache roi
-        self.roi = roi
+        self.roi = roi if isinstance(roi, tuple) else daria.bounding_box(roi)
 
         # Define a translation estimator
         self.translation_estimator = daria.TranslationEstimator()

--- a/src/daria/utils/box.py
+++ b/src/daria/utils/box.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 
-def bounding_box(coords: np.array) -> tuple:
+def bounding_box(coords: np.ndarray) -> tuple:
     """
     Determine bounding box for a set of given coordinates.
 

--- a/src/daria/utils/box.py
+++ b/src/daria/utils/box.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+
+def bounding_box(coords: np.array) -> tuple:
+    """
+    Determine bounding box for a set of given coordinates.
+
+    Args:
+        coords (np.ndarray): coordinate array of size N x dim.
+
+    Returns:
+        tuple of slices: slices with ranges from min to max value
+            per dimension.
+    """
+    bounding_box = ()
+
+    for dim in range(coords.shape[1]):
+        min_value = np.min(coords[:, dim])
+        max_value = np.max(coords[:, dim])
+        bounding_box = *bounding_box, slice(min_value, max_value)
+
+    return bounding_box


### PR DESCRIPTION
`daria.DriftCorrection` requires a tuple of slices as ROI, while `daria.ColorCorrection` works best for ROIs provided by providing a set of coordinates to define a quadrilateral. This PR adds a simple util function, which computes the bounding box for a set of coorinates, returned as tuple of slices. Thus, this can be used to convert from one to the other. This functionality is integrated in `daria.DriftCorrection` to mitigate the need for defining two different ROIs when possibly wanting to identifying a color palette as fixed point. 