### PR TITLE
Split I/O of the cleaning filter in the concentration analysis

### DIFF
--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -7,6 +7,7 @@ import copy
 import json
 from pathlib import Path
 from typing import Optional, Union
+from warnings import warn
 
 import cv2
 import matplotlib.pyplot as plt
@@ -116,6 +117,11 @@ class ConcentrationAnalysis:
             config (dict): config file for simple data.
             path (str or Path): path to cleaning filter array.
         """
+        warn(
+            "Routine deprecated. Instead read scaling parameter from config and use"
+            "read_cleaning_filter_from_file()."
+        )
+
         # Fetch the scaling parameter and threshold mask from file
         self.scaling = config["scaling"]
         self.threshold = np.load(path)
@@ -136,6 +142,8 @@ class ConcentrationAnalysis:
             path_to_config (str or Path): path for storage of config file.
             path_to_filter (str or Path): path for storage of the cleaning filter.
         """
+        warn("Routine deprecated. Instead use write_cleaning_filter_to_file().")
+
         # Store scaling parameters.
         config = {
             "scaling": self.scaling,
@@ -144,6 +152,30 @@ class ConcentrationAnalysis:
             json.dump(config, outfile, indent=4)
 
         # Store cleaning filter array.
+        np.save(str(Path(path_to_filter)), self.threshold)
+
+    def read_cleaning_filter_from_file(self, path: Union[str, Path]) -> None:
+        """
+        Read cleaning filter from file.
+
+        Args:
+            path (str or Path): path to cleaning filter array.
+        """
+        # Fetch the threshold mask from file
+        self.threshold = np.load(path)
+
+        # Resize threshold mask if unmatching the size of the base image
+        base_shape = self.base.img.shape[:2]
+        if self.threshold.shape[:2] != base_shape:
+            self.threshold = cv2.resize(self.threshold, tuple(reversed(base_shape)))
+
+    def write_cleaning_filter_to_file(self, path_to_filter: Union[str, Path]) -> None:
+        """
+        Store cleaning filter to file.
+
+        Args:
+            path_to_filter (str or Path): path for storage of the cleaning filter.
+        """
         np.save(str(Path(path_to_filter)), self.threshold)
 
     # ! ---- Main method

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -5,7 +5,6 @@ analyze concentrations/saturation profiles based on image comparison.
 
 import copy
 import json
-import warnings
 from pathlib import Path
 from typing import Optional, Union
 

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -530,8 +530,9 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
             np.ndarray: prior binary mask
         """
 
-        # Deactive signal outside mask
-        signal[~self.mask] = 0
+        if self.verbosity:
+            plt.figure("Prior: Input signal")
+            plt.imshow(signal)
 
         # Apply presmoothing
         if self.apply_presmoothing:
@@ -678,7 +679,7 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
             plt.imshow(mask)
 
         # Finaly cleaning - deactive signal outside mask
-        signal[~self.mask] = 0
+        mask[~self.mask] = 0
 
         if self.verbosity:
             plt.figure("Prior: Final mask after cleaning")

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -502,6 +502,10 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
     def update_mask(self, mask: np.ndarray) -> None:
         """
         Update the mask to be considered in the analysis.
+
+        Args:
+            mask (np.ndarray): boolean mask, detecting which pixels will
+                be considered, al other will be ignored in the analysis.
         """
         self.mask = mask
 

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -507,7 +507,7 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
 
         Args:
             mask (np.ndarray): boolean mask, detecting which pixels will
-                be considered, al other will be ignored in the analysis.
+                be considered, all other will be ignored in the analysis.
         """
         self.mask = mask
 
@@ -680,7 +680,7 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
             plt.figure("Prior: TVD postsmoothed mask")
             plt.imshow(mask)
 
-        # Finaly cleaning - deactive signal outside mask
+        # Finaly cleaning - inactive signal outside mask
         mask[~self.mask] = 0
 
         if self.verbosity:

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -5,9 +5,9 @@ analyze concentrations/saturation profiles based on image comparison.
 
 import copy
 import json
+import warnings
 from pathlib import Path
 from typing import Optional, Union
-from warnings import warn
 
 import cv2
 import matplotlib.pyplot as plt
@@ -117,9 +117,9 @@ class ConcentrationAnalysis:
             config (dict): config file for simple data.
             path (str or Path): path to cleaning filter array.
         """
-        warn(
-            "Routine deprecated. Instead read scaling parameter from config and use"
-            "read_cleaning_filter_from_file()."
+        raise PendingDeprecationWarning(
+            "Routine deprecated, and will be removed in the future. Instead read scaling"
+            "parameter from config and use read_cleaning_filter_from_file()."
         )
 
         # Fetch the scaling parameter and threshold mask from file
@@ -142,7 +142,10 @@ class ConcentrationAnalysis:
             path_to_config (str or Path): path for storage of config file.
             path_to_filter (str or Path): path for storage of the cleaning filter.
         """
-        warn("Routine deprecated. Instead use write_cleaning_filter_to_file().")
+        raise PendingDeprecationWarning(
+            "Routine deprecated, and will be removed in the future. Instead use"
+            "write_cleaning_filter_to_file()."
+        )
 
         # Store scaling parameters.
         config = {

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -397,7 +397,7 @@ class CurvatureCorrection:
         if (pt_dst[0] - pt_src[0]) == 0:
             horizontal_stretch = 0
         # Check whether point is chosen too close to the center
-        # (within 10% of total pixels), and make warning
+        # (within 5% of total pixels), and make warning
         elif abs(pt_src[0] - stretch_center[0]) < round(0.05 * Nx):
             horizontal_stretch = 0
             warn(


### PR DESCRIPTION
So far `daria.ConcentrationAnalysis` provides I/O for scaling parameters and cleaning filters. However, the combination does not always make much sense (in particular when there is no scaling). Therefore, a split of the two is suggested, and a separate I/O routine for the cleaning filter is provided. The old routines are kept for now (due to use in other projects) but ammended by a deprecation warning. They should be removed at some point, in coordination with updating projects using DarIA.

In addition, small fixes are included (doc, verbosity, and a small non-critical bug). 