### PR TITLE
Reading images and converting to RGB 

### DIFF
--- a/src/daria/corrections/shape/drift.py
+++ b/src/daria/corrections/shape/drift.py
@@ -9,8 +9,8 @@ import json
 from pathlib import Path
 from typing import Optional, Union
 
+import cv2
 import numpy as np
-from PIL import Image as PIL_Image
 
 import daria
 
@@ -40,8 +40,8 @@ class DriftCorrection:
 
         # Read baseline image
         if isinstance(base, str) or isinstance(base, Path):
-            pil_base = PIL_Image.open(Path(base))
-            self.base = np.array(pil_base)
+            base_BGR = cv2.imread(str(Path(base)), cv2.IMREAD_UNCHANGED)
+            self.base = cv2.cvtColor(base_BGR, cv2.COLOR_BGR2RGB)
         elif isinstance(base, np.ndarray):
             self.base = np.copy(base)
         elif isinstance(base, daria.Image):

--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -159,12 +159,14 @@ class Image:
                 "Invalid image data. Provide either a path to an image or an image array."
             )
 
+        # Convert to RGB
+        self.toRGB()
+
         # Apply corrections
         if drift_correction is not None:
             self.img = drift_correction(self.img)
 
         if color_correction is not None:
-            self.toRGB()
             self.img = color_correction(self.img)
 
         if curvature_correction is not None:


### PR DESCRIPTION
So far, when no `color_correction` has been defined in `daria.Image`, no converison to RGB has been applied. When reading already converted images, one does not necessarily want to define and apply empty correction (which still would take time to execute). Hence, the transformation to RGB is applied always.

In `DriftCorrection`, so far `PIL` has been used to read images. In view of the changes in #79 the baseline image in `DriftCorrection` however should also be read in the same format as in `Image`. Thus, also `cv2.imread` is used here, with the same options to read int16 images.