### PR TITLE
Add first managers

### DIFF
--- a/src/daria/__init__.py
+++ b/src/daria/__init__.py
@@ -30,3 +30,5 @@ from daria.analysis.translationanalysis import *
 from daria.analysis.concentrationanalysis import *
 from daria.analysis.compactionanalysis import *
 from daria.analysis.segmentationcomparison import *
+from daria.manager.analysisbase import *
+from daria.manager.traceranalysis import *

--- a/src/daria/__init__.py
+++ b/src/daria/__init__.py
@@ -19,8 +19,6 @@ from daria.mathematics.regularization import *
 from daria.utils.conversions import *
 from daria.utils.resolution import *
 from daria.utils.box import *
-from daria.utils.segmentation import *
-from daria.utils.coloranalysis import *
 from daria.corrections.shape.curvature import *
 from daria.corrections.shape.translation import *
 from daria.corrections.shape.piecewiseperspective import *

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -5,7 +5,6 @@ analyze concentrations/saturation profiles based on image comparison.
 
 import copy
 import json
-import warnings
 from pathlib import Path
 from typing import Optional, Union
 

--- a/src/daria/analysis/concentrationanalysis.py
+++ b/src/daria/analysis/concentrationanalysis.py
@@ -507,7 +507,7 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
 
         Args:
             mask (np.ndarray): boolean mask, detecting which pixels will
-                be considered, al other will be ignored in the analysis.
+                be considered, all other will be ignored in the analysis.
         """
         self.mask = mask
 
@@ -680,7 +680,7 @@ class BinaryConcentrationAnalysis(ConcentrationAnalysis):
             plt.figure("Prior: TVD postsmoothed mask")
             plt.imshow(mask)
 
-        # Finaly cleaning - deactive signal outside mask
+        # Finaly cleaning - inactive signal outside mask
         mask[~self.mask] = 0
 
         if self.verbosity:

--- a/src/daria/manager/analysisbase.py
+++ b/src/daria/manager/analysisbase.py
@@ -57,7 +57,7 @@ class AnalysisBase:
             config=self.config["geometry"]
         )
 
-        # Define baseline image as corrected daria Image - if exists use cached image
+        # Define baseline image as corrected daria Image
         self.base = self._read(reference_base)
 
     # ! ----- I/O

--- a/src/daria/manager/analysisbase.py
+++ b/src/daria/manager/analysisbase.py
@@ -1,0 +1,95 @@
+"""
+Module providing structures for common analyses. In practice, such may
+have to be tailored to the specific scenario. Yet, they already provide
+many of the most relevant functionalities. If not applicable, they also
+provide the approach for how to set up tailored analysis classes.
+"""
+
+import json
+from pathlib import Path
+from typing import Union
+
+import daria
+
+
+class AnalysisBase:
+    """
+    Standard setup for an image analysis, in particular useful when analyzing
+    a larger set of images in a time series.
+    """
+
+    def __init__(
+        self,
+        baseline: Union[str, Path, list[str], list[Path]],
+        config: Union[str, Path],
+        update_setup: bool = False,
+    ) -> None:
+        """
+        Constructor for GeneralAnalysis.
+
+        Sets up fixed config file required for preprocessing.
+
+        Args:
+            baseline (str, Path or list of such): baseline images, used to
+                set up analysis tools and cleaning tools
+            config (str or Path): path to config dict
+            update_setup (bool): flag controlling whether cache in setup
+                routines is emptied.
+        """
+        # Read general config file
+        f = open(config, "r")
+        self.config = json.load(f)
+        f.close()
+
+        # Define set of baseline images and initiate object for caching
+        # processed baseline images.
+        if not isinstance(baseline, list):
+            baseline = [baseline]
+        reference_base = baseline[0]
+        self.processed_baseline_images = None
+
+        # Define correction objects
+        self.drift_correction = daria.DriftCorrection(
+            base=reference_base, roi=self.config["drift"]["roi"]
+        )
+        self.color_correction = daria.ColorCorrection(roi=self.config["color"]["roi"])
+        self.curvature_correction = daria.CurvatureCorrection(
+            config=self.config["geometry"]
+        )
+
+        # Define baseline image as corrected daria Image - if exists use cached image
+        self.base = self._read(reference_base)
+
+    # ! ----- I/O
+
+    def _read(self, path: Union[str, Path]) -> daria.Image:
+        """
+        Auxiliary reading methods for daria Images.
+
+        Args:
+            path (str or Path): path to file.
+
+        Returns:
+            daria.Image: image corrected for curvature and color.
+        """
+
+        print(f"Reading image from {str(path)}.")
+
+        return daria.Image(
+            img=path,
+            drift_correction=self.drift_correction,
+            curvature_correction=self.curvature_correction,
+            color_correction=self.color_correction,
+            # get_timestamp=True,
+        )
+
+    def load_and_process_image(self, path: Union[str, Path]) -> None:
+        """
+        Load image for further analysis. Do all corrections and processing needed.
+
+        Args:
+            path (str or Path): path to image
+        """
+
+        # Read and process
+        self.img = self._read(path)

--- a/src/daria/manager/traceranalysis.py
+++ b/src/daria/manager/traceranalysis.py
@@ -1,0 +1,104 @@
+"""
+Module providing structures for tracer analysis. The resulting class is
+abstract and needs to be tailored to the specific situation by inheritance.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Union
+
+import daria
+
+# TODO make tracer analysis a child of multicomponentanalysis with num_components=1?
+
+
+class TracerAnalysis(ABC, daria.AnalysisBase):
+    def __init__(
+        self,
+        baseline: Union[str, Path, list[str], list[Path]],
+        config: Union[str, Path],
+        update_setup: bool = False,
+    ) -> None:
+        """
+        Constructor for CO2Analysis.
+
+        Args:
+            baseline (str, Path or list of such): see daria.GeneralAnalysis.
+            config_source (str or Path): see daria.GeneralAnalysis.
+            update_setup (bool): see daria.GeneralAnalysis.
+        """
+        super().__init__(baseline, config, update_setup)
+
+        # Define concentration analysis including determining a cleaning filter.
+        self.define_concentration_analysis()
+        self._setup_concentration_analysis(
+            self.concentration_analysis,
+            self.config["concentration"]["cleaning_filter"],
+            baseline,
+            update_setup,
+        )
+
+    @abstractmethod
+    def define_concentration_analysis(self) -> None:
+        """
+        The main purpose of this routine is to define self.concentration_analysis,
+        which lies at the heart of this class. It is supposed to determine concentrations
+        from image differences. Since the choice of a suitable color channel etc.
+        may heavily depend on the situation, this method is abstract and has to
+        be overwritten in each specific situation.
+        """
+        pass
+
+    # ! ---- Auxiliary setup routines
+
+    def _setup_concentration_analysis(
+        self,
+        concentration_analysis: daria.ConcentrationAnalysis,
+        cleaning_filter: Union[str, Path],
+        baseline_images: list[Union[str, Path]],
+        update: bool = False,
+    ) -> None:
+        """
+        Wrapper to find cleaning filter of the concentration analysis.
+
+        Args:
+            concentration_analysis (daria.ConcentrationAnalysis): concentration analysis
+                to be set up.
+            cleaning_filter (str or Path): path to cleaning filter array.
+            baseline_images (list of str or Path): paths to baseline images.
+            update (bool): flag controlling whether the calibration and setup should
+                be updated.
+        """
+        # Set volume information
+        # TODO include; after also including self.determine_effective_volumes (abstractmethod).
+        #        concentration_analysis.update_volumes(self.effective_volumes)
+
+        # Fetch or generate cleaning filter
+        if not update and Path(cleaning_filter).exists():
+            concentration_analysis.read_cleaning_filter_from_file(cleaning_filter)
+        else:
+            # Process baseline images used for setting up the cleaning filter
+            if self.processed_baseline_images is None:
+                self.processed_baseline_images = [
+                    self._read(path) for path in baseline_images
+                ]
+
+            # Construct the concentration analysis specific cleaning filter
+            concentration_analysis.find_cleaning_filter(self.processed_baseline_images)
+
+            # Store the cleaning filter to file for later reuse.
+            concentration_analysis.write_cleaning_filter_to_file(cleaning_filter)
+
+    def determine_concentration(self) -> daria.Image:
+        """Extract tracer from currently loaded image, based on a reference image.
+
+        Returns:
+            daria.Image: image array of spatial concentration map
+        """
+        # Make a copy of the current image
+        img = self.img.copy()
+
+        # Extract concentration map - includes rescaling
+        concentration = self.concentration_analysis(img)
+
+        return concentration


### PR DESCRIPTION
In order to simplify the setup of analysis objects for dedicated studies, managing classes are intended for such use. This PR adds two first objects targeting this purpose. At the moment, a general base class is added, and a class towards tracer analysis. In near future, also an additional object tailored to CO2 analyses will be added.

Important: When setting up all my run scripts to analyze the benchmark data, I have not used the recent keyword choices introduced in the correction objects of daria. Instead, I have been using nested config files, to allow for some structure. As currently implemented, the managers explicitly expect such a nested structure. Thus, a unified choice will have to be made, what style daria is expecting, and all script will have to be adapted. At the moment, this is not the purpose of this PR, so I am keeping the style I have been using.