### PR TITLE
Add functionality applying the deformation/compaction map to any image

### DIFF
--- a/src/daria/analysis/compactionanalysis.py
+++ b/src/daria/analysis/compactionanalysis.py
@@ -108,3 +108,19 @@ class CompactionAnalysis:
             deformation = base.coordinatesystem.pixelToCoordinateVector(deformation)
 
         return deformation
+
+    def apply(self, img: daria.Image) -> daria.Image:
+        """
+        Apply computed transformation onto arbitrary image.
+
+        Args:
+            img (np.ndarray or daria.Image): image
+
+        Returns:
+            np.ndarray, optional: transformed image, if input is array; no output otherwise
+        """
+        # Load the image into translation_analysis
+        self.translation_analysis.load_image(img)
+
+        # Apply the transformation, stored in translation_analysis
+        return self.translation_analysis.translate_image()


### PR DESCRIPTION
The `CompactionAnalysis` operates on two images, a source and destination image. It can determine the deformation from one to the other and also stores the deformation map. It can be evaluated. This PR adds the functionality to apply this deformation map to any input, which can be also different from the source and destination images. 

Example use case: A use case is/can be the deformation of the segmentation of an baseline geometry of a FluidFlower from one to another scenario. When compaction occurs or a different config file is used for `CurvatureCorrection`, also the segmentation is changing. By applying the computed deformation map, a previously computed segmentation (which may be slightly hardcoded), can be transferred without enterring further tuning etc.