### PR TITLE
FIX: uint16-> uint8 in extract_roi

### DIFF
--- a/src/daria/utils/features.py
+++ b/src/daria/utils/features.py
@@ -5,7 +5,6 @@ from typing import Optional
 
 import cv2
 import numpy as np
-
 import skimage
 
 
@@ -45,7 +44,7 @@ class FeatureDetection:
         img_gray = cv2.cvtColor(img_roi, cv2.COLOR_RGB2GRAY)
 
         # Orb does not allow for uint16, so convert to uint8.
-        if (img_gray.dtype == np.uint16):
+        if img_gray.dtype == np.uint16:
             img_gray = skimage.img_as_ubyte(img_gray)
 
         # Determine matching features; use ORB to detect keypoints

--- a/src/daria/utils/features.py
+++ b/src/daria/utils/features.py
@@ -6,6 +6,8 @@ from typing import Optional
 import cv2
 import numpy as np
 
+import skimage
+
 
 class FeatureDetection:
     """
@@ -41,6 +43,10 @@ class FeatureDetection:
 
         # Convert to gray color space
         img_gray = cv2.cvtColor(img_roi, cv2.COLOR_RGB2GRAY)
+
+        # Orb does not allow for uint16, so convert to uint8.
+        if (img_gray.dtype == np.uint16):
+            img_gray = skimage.img_as_ubyte(img_gray)
 
         # Determine matching features; use ORB to detect keypoints
         # and extract (binary) local invariant features


### PR DESCRIPTION
Found out (together with Benyamine) that cv2's orb doesn't allow for the gray images to be of uint16 type. A fix is to use skimage to convert image to uint8 if that is the case. It seems to work well.