### PR TITLE
Compute contour length of segmentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ grid_image = image.add_grid(origo = [5, 2], dx = 10, dy = 10)
 grid_image.show()
 
 # Extract region of interest (ROI) from image:
-ROI_image = da.extractROI(image, [150, 280], [0, 70])
+ROI_image = da.extractROI(image, [[150, 0], [280, 70]])
 ROI_image.show()
 ```
 

--- a/examples/notebooks/brief_tutorial.ipynb
+++ b/examples/notebooks/brief_tutorial.ipynb
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If one would rather like to extract a ROI, defines as box with corners [10, 20] and [50, 70] (in physical physical coordinates), this is possible by the use of the command below:"
+    "If one would rather like to extract a ROI, defined as a box with corners [10, 20] and [50, 70] (in physical physical coordinates), this is possible by the use of the command below:"
    ]
   },
   {

--- a/examples/notebooks/brief_tutorial.ipynb
+++ b/examples/notebooks/brief_tutorial.ipynb
@@ -76,7 +76,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If one would rather like to extract a ROI thought physical coordinates, in the coordinates 10 to 50 in the x-direction and 20 to 70 in the y-direction this is possible by the use of the command below:"
+    "If one would rather like to extract a ROI, defines as box with corners [10, 20] and [50, 70] (in physical physical coordinates), this is possible by the use of the command below:"
    ]
   },
   {
@@ -85,7 +85,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ROI_phys = da.extractROI(baseline_image, [10,50], [20, 70])\n",
+    "ROI_phys = da.extractROI(baseline_image, [[10,20], [50, 70]])\n",
     "ROI_phys.plt_show()"
    ]
   },

--- a/src/daria/__init__.py
+++ b/src/daria/__init__.py
@@ -31,6 +31,7 @@ from daria.analysis.translationanalysis import *
 from daria.analysis.concentrationanalysis import *
 from daria.analysis.compactionanalysis import *
 from daria.analysis.segmentationcomparison import *
+from daria.analysis.contouranalysis import *
 from daria.manager.analysisbase import *
 from daria.manager.concentrationanalysisbase import *
 from daria.manager.traceranalysis import *

--- a/src/daria/analysis/contouranalysis.py
+++ b/src/daria/analysis/contouranalysis.py
@@ -1,0 +1,85 @@
+"""
+Module containing analysis tools for segmented images. This includes
+measuring lengths of contours, weighted sums (generalized mass analysis).
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import matplotlib.pyplot as plt
+import numpy as np
+import scipy.ndimage as ndi
+import skimage
+
+import daria
+
+
+def contour_length(
+    img: daria.Image,
+    roi: Optional[np.ndarray] = None,
+    values_of_interest: Optional[Union[int, list[int]]] = None,
+    fill_holes: bool = True,
+    verbosity: bool = False,
+) -> float:
+    """
+    Calculation of the contour length of a segmented region.
+
+    Args:
+        img (daria.Image): segmented image with boolean or integer values.
+        roi (np.ndarray): set of points, for which a bounding box defines a ROI.
+        values_of_interest (int or list of int): only active if integer-valued
+            image provided; defines the values of interest, i.e., which part
+            of the image is treated as active.
+        fill_holes (bool): flag controlling whether holes in the determined mask
+            are filled before the contour length is computed; if not, holes are
+            treated as contour; default is True.
+        verbosity (bool): flag controlling whether intermediate results are plotted;
+            default is False.
+
+    Returns:
+        float: contour length in metric units based on the coordinate system of the
+            input image.
+    """
+    # Make copy of image and restrict to region of interest
+    img_roi = img.copy if roi is None else daria.extractROI(img, roi)
+
+    # Extract boolean mask covering pixels of interest.
+    if img_roi.img.dtype == bool:
+        mask: np.ndarray = img_roi.img
+    elif img_roi.img.dtype in [np.uint8, np.int32, np.int64]:
+        assert values_of_interest is not None
+        mask = np.zeros(img_roi.img.shape[:2], dtype=bool)
+        for value in values_of_interest:
+            mask[img_roi.img == value] = True
+    else:
+        raise ValueError(f"Images with dtype {img_roi.img.dtype} not supported.")
+
+    # Fill all holes
+    if fill_holes:
+        mask = ndi.binary_fill_holes(mask)
+
+    # Obtain connected and covered regions and region properties
+    label_img, num_labels = skimage.measure.label(mask, return_num=True)
+    props = skimage.measure.regionprops(label_img)
+
+    # Determine the length of all contours and sum up
+    contour_length = 0.0
+    for counter in range(num_labels):
+        # Add the perimeter for the region with label l+1 (0 is ignored in regionprops).
+        contour_length += props[counter].perimeter
+
+    # Convert contour length from pixel units to metric units
+    metric_contour_length = img_roi.coordinatesystem.pixelsToLength(contour_length)
+
+    # Plot masks and print contour length if requested.
+    if verbosity:
+        plt.figure()
+        plt.imshow(img.img)
+        plt.figure()
+        plt.imshow(img_roi.img)
+        plt.figure()
+        plt.imshow(mask)
+        plt.show()
+        print(f"The contour length is {metric_contour_length}.")
+
+    return metric_contour_length

--- a/src/daria/image/subregions.py
+++ b/src/daria/image/subregions.py
@@ -1,15 +1,16 @@
 """
 Module containing auxiliary methods to extract ROIs from daria Images.
 """
+from typing import Union
+
 import cv2
 import numpy as np
 
 import daria
-from typing import Union
 
 
 def extractROI(
-        img: daria.Image, pts: Union[np.ndarray, list], return_roi: bool = False
+    img: daria.Image, pts: Union[np.ndarray, list], return_roi: bool = False
 ) -> daria.Image:
     """Extracts region of interest based on physical coordinates.
 
@@ -30,8 +31,8 @@ def extractROI(
     # Convert metric units to number of pixels, and define top-left and bottom-right
     # corners of the roi, towards addressing the image with matrix indexing
     # of x and y coordinates.
-    top_left_coordinate = [np.min(pts[:,0]), np.max(pts[:,1])]
-    bottom_right_coordinate = [np.max(pts[:,0]), np.min(pts[:,1])]
+    top_left_coordinate = [np.min(pts[:, 0]), np.max(pts[:, 1])]
+    bottom_right_coordinate = [np.max(pts[:, 0]), np.min(pts[:, 1])]
     top_left_pixel = img.coordinatesystem.coordinateToPixel(top_left_coordinate)
     bottom_right_pixel = img.coordinatesystem.coordinateToPixel(bottom_right_coordinate)
 
@@ -42,9 +43,9 @@ def extractROI(
     )
 
     # Define metadata (all quantities in metric units)
-    origo = [np.min(pts[:,0]), np.min(pts[:,1])]
-    width = np.max(pts[:,0]) - np.min(pts[:,0])
-    height = np.max(pts[:,1]) - np.min(pts[:,1])
+    origo = [np.min(pts[:, 0]), np.min(pts[:, 1])]
+    width = np.max(pts[:, 0]) - np.min(pts[:, 0])
+    height = np.max(pts[:, 1]) - np.min(pts[:, 1])
 
     # Construct and return image corresponding to ROI
     if return_roi:


### PR DESCRIPTION
Add capability which computes the contour length of a boolean or integer-values array (restricted to prescribed values) and restricted to a ROI. This allows to perform e.g. a fingering analysis for CO2 storage experiments.

As part of this PR (as it is also used in the main change): `extractROI` has been updated, using an alternative approach (more compatible to other places in daria, I believe) to define a ROI. By providing a list/array of coordinates, essentially a bounding box is defined. This can be reverted if not agreed upon. 