### PR TITLE
Add possibility to address negatives of boolean masks

### DIFF
--- a/src/daria/analysis/contouranalysis.py
+++ b/src/daria/analysis/contouranalysis.py
@@ -48,7 +48,7 @@ def contour_length(
         if values_of_interest is None:
             mask: np.ndarray = img_roi.img
         else:
-            mask = np.zeros(img_roi.img.shape[:2], dtype=bool)
+            mask = np.zeros_like(img_roi.img, dtype=bool)
             for value in values_of_interest:
                 mask[img_roi.img == value] = True
     elif img_roi.img.dtype in [np.uint8, np.int32, np.int64]:

--- a/src/daria/analysis/contouranalysis.py
+++ b/src/daria/analysis/contouranalysis.py
@@ -45,7 +45,12 @@ def contour_length(
 
     # Extract boolean mask covering pixels of interest.
     if img_roi.img.dtype == bool:
-        mask: np.ndarray = img_roi.img
+        if values_of_interest is None:
+            mask: np.ndarray = img_roi.img
+        else:
+            mask = np.zeros(img_roi.img.shape[:2], dtype=bool)
+            for value in values_of_interest:
+                mask[img_roi.img == value] = True
     elif img_roi.img.dtype in [np.uint8, np.int32, np.int64]:
         assert values_of_interest is not None
         mask = np.zeros(img_roi.img.shape[:2], dtype=bool)


### PR DESCRIPTION
It turned out to be useful to be able to compute the contour line of the logical negative of a boolean image. Therefore this possibility has been added to the contour analysis.