### PR TITLE
Provide setter for timestamp of Image.

### DIFF
--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -193,6 +193,8 @@ class Image:
         # Establish a coordinate system based on the metadata
         self.coordinatesystem: da.CoordinateSystem = da.CoordinateSystem(self)
 
+    # ! ---- Fast-access getter functions for metadata
+
     @property
     def origo(self) -> list:
         return self.metadata["origo"]
@@ -216,6 +218,12 @@ class Image:
     @property
     def original_dtype(self) -> np.dtype:
         return self.metadata["original_dtype"]
+
+    # ! ---- Corresponding setter functions for metadata
+
+    @timestamp.setter
+    def timestamp(self, time: datetime.datetime) -> None:
+        self.metadata["timestamp"] = time
 
     def write(
         self,


### PR DESCRIPTION
Optimally, metadata should be created at the initiation of an `Image`. However, some of the metadata is not crucial and may even be set to default values as `None`. This also holds for `timestamp`. For such properties it is not a big deal to add a setter method. This PR adds a setter method for `timestamp`. It allows to ammend the metadata of an `Image` with a corresponding time, also after the initialization. This turns out to be a very convenient way of reading images with times, e.g. hardcoded in the file names.