### PR TITLE
Bugfix in segmentationcomparison.

### DIFF
--- a/src/daria/analysis/segmentationcomparison.py
+++ b/src/daria/analysis/segmentationcomparison.py
@@ -167,10 +167,17 @@ class SegmentationComparison:
         # or an array of corner points
         if "roi" in kwargs:
             roi_input = kwargs["roi"]
-            if isinstance(roi_input, np.ndarray):
-                roi: tuple = da.bounding_box(roi_input)
-            elif isinstance(roi_input, tuple):
-                roi = roi_input
+            if isinstance(roi_input, tuple):
+                roi: tuple = roi_input
+            elif isinstance(roi_input, np.ndarray):
+                roi = da.bounding_box(roi_input)
+            elif isinstance(roi_input, list):
+                roi = da.bounding_box(np.array(roi_input))
+            else:
+                raise Exception(
+                    f"{type(roi_input)} is not a valid type for roi. Please provide it as"
+                    " a tuple of slices, or an array or list of corner points"
+                )
             return_image: np.ndarray = np.zeros(
                 (roi[0].stop - roi[0].start, roi[1].stop - roi[1].start) + (3,),
                 dtype=np.uint8,

--- a/src/daria/analysis/segmentationcomparison.py
+++ b/src/daria/analysis/segmentationcomparison.py
@@ -8,7 +8,7 @@ as well as methods for comparing them and visualizing the result.
 
 from __future__ import annotations
 
-from typing import Optional, cast
+from typing import Optional
 
 import cv2
 import matplotlib.patches as mpatches
@@ -172,8 +172,7 @@ class SegmentationComparison:
             elif isinstance(roi_input, tuple):
                 roi = roi_input
             return_image: np.ndarray = np.zeros(
-                (roi[0].stop - roi[0].start, roi[1].stop - roi[1].start)
-                + (3,),
+                (roi[0].stop - roi[0].start, roi[1].stop - roi[1].start) + (3,),
                 dtype=np.uint8,
             )
 


### PR DESCRIPTION
When I included the possibility to have the roi as an array, an unfortunate "redefinition" of the roi led to malfunction. It is working as intended now now.