### PR TITLE
Extend compaction example

### DIFF
--- a/examples/compaction_analysis.py
+++ b/examples/compaction_analysis.py
@@ -68,7 +68,12 @@ compaction_analysis = daria.CompactionAnalysis(da_img_src, **config["compaction"
 
 # Apply compaction analysis, providing the deformed image matching the baseline image.
 # Also plot the deformation as vector field.
-da_new_image = compaction_analysis(da_img_dst, plot=True, reverse=True)
+da_new_image, patch_translation = compaction_analysis(
+    da_img_dst, reverse=True, plot_patch_translation=True, return_patch_translation=True
+)
+
+print("The centers of the 20 x 10 patches are translated:")
+print(patch_translation)
 
 # Plot the differences between the two original images and after the transformation.
 fig, ax = plt.subplots(1, num=1)
@@ -88,7 +93,37 @@ pts = np.array(
         [2.3, 1.1],
     ]
 )
+print("Consider the points:")
+print(pts)
 
 deformation = compaction_analysis.evaluate(pts)
 print("Deformation evaluated:")
 print(deformation)
+
+# One can also use a patched ROI and evaluate the deformation in the patch centers.
+# For this, we start extracting a roi, here we choose a box, which in the end
+# corresponds to box B from the benchmark analysis. This it is sufficient to
+# define two corner points of the box:
+box_B = np.array([[0.0, 1.2], [1.1, 0.6]])
+
+# and extract the corresponding ROI as daria.Image (based on da_img_src):
+img_box_B = daria.extractROI(da_img_src, box_B)
+
+# To double check the box, we plot the resulting box.
+plt.figure("Box B")
+plt.imshow(img_box_B.img)
+plt.show()
+
+# Now we patch box B, the number of patches is arbitrary (here chosen to be 5 x 3):
+patches_box_B = daria.Patches(img_box_B, 5, 3)
+
+# The patch centers can be accessed:
+patch_centers_box_B = patches_box_B.global_centers_cartesian
+
+# The deformation in the centers of these points can be obtained by evaluating the
+# deformation map in a similar fashion as above. The results comes in a matrix.
+# Entry [row,col] is associated to patch with coordinate [row,col] using the
+# conventional matrix indexing.
+deformation_patch_centers_box_B = compaction_analysis.evaluate(patch_centers_box_B)
+print("The deformation in the centers of the patches of Box B:")
+print(deformation_patch_centers_box_B)

--- a/src/daria/analysis/compactionanalysis.py
+++ b/src/daria/analysis/compactionanalysis.py
@@ -53,8 +53,8 @@ class CompactionAnalysis:
     def __call__(
         self,
         img: daria.Image,
-        plot: bool = False,
         reverse: bool = False,
+        plot_patch_translation: bool = False,
         return_patch_translation: bool = False,
     ):
         """
@@ -65,22 +65,27 @@ class CompactionAnalysis:
 
         Args:
             img (daria.Image): test image
-            plot (bool): flag controlling whether the deformation is also
-                visualized as vector field.
             reverse (bool): flag whether the translation is understood as from the
                 test image to the baseline image, or reversed. The default is the
                 former one.
+            plot_patch_translation (bool): flag controlling whether the deformation is also
+                visualized as vector field.
             return_patch_translation (bool): flag controlling whether the deformation
                 in the patch centers is returned in the sense of dst to src image,
                 complying to the plot; default is False.
         """
         transformed_img = self.translation_analysis(img)
+
         if return_patch_translation:
             patch_translation = self.translation_analysis.return_patch_translation()
-            return transformed_img, patch_translation
-        if plot:
+
+        if plot_patch_translation:
             self.translation_analysis.plot_translation()
-        return transformed_img
+
+        if return_patch_translation:
+            return transformed_img, patch_translation
+        else:
+            return transformed_img
 
     def evaluate(self, coords: np.ndarray, units: str = "metric") -> np.ndarray:
         """

--- a/src/daria/image/image.py
+++ b/src/daria/image/image.py
@@ -114,8 +114,8 @@ class Image:
             else:
                 raise Exception("image height not specified")
 
-            self.metadata["origo"]: np.ndarray[float] = kwargs.pop(
-                "origo", np.array([0, 0])
+            self.metadata["origo"]: np.ndarray[float] = np.array(
+                kwargs.pop("origo", np.array([0, 0]))
             )
 
             no_colorspace_given = "color_space" not in kwargs

--- a/src/daria/image/subregions.py
+++ b/src/daria/image/subregions.py
@@ -1,6 +1,7 @@
 """
 Module containing auxiliary methods to extract ROIs from daria Images.
 """
+import warnings
 from typing import Union
 
 import cv2
@@ -38,9 +39,16 @@ def extractROI(
 
     # Define the ROI in terms of pixels, using matrix indexing, i.e., the (row,col) format
     roi = (
-        slice(top_left_pixel[0], bottom_right_pixel[0]),
-        slice(top_left_pixel[1], bottom_right_pixel[1]),
+        slice(max(0, top_left_pixel[0]), min(img.img.shape[0], bottom_right_pixel[0])),
+        slice(max(0, top_left_pixel[1]), min(img.img.shape[1], bottom_right_pixel[1])),
     )
+
+    if (
+        min(top_left_pixel[0], top_left_pixel[1]) < 0
+        or bottom_right_pixel[0] > img.img.shape[0]
+        or bottom_right_pixel[1] > img.img.shape[1]
+    ):
+        warnings.warn("Provided coordinates lie outside image.")
 
     # Define metadata (all quantities in metric units)
     origo = [np.min(pts[:, 0]), np.min(pts[:, 1])]


### PR DESCRIPTION
On request, the capabilities of the compaction analysis have been extended. Now it is also possible to return the effective deformation/translation in the patch centers, after evaluating the compaction analysis. The example for compaction analysis is updated accordinaly.

In addition it is showcased how to evaluate the deformation map in arbitrary ROIs and patch centers after deriving it. 