### PR TITLE
Store the curvature correcion operation to file

### DIFF
--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -68,9 +68,6 @@ class CurvatureCorrection:
                 in_meters (bool): returns True if width and height are given
                             in terms of meters. Only relevant if image
                             is provided.
-                use_cache (bool): flag controlling whether the tranformation
-                            map should be fetched from cache.
-                cache (Union[Path, str]): path to cached transformation map.
         """
 
         if config is not None:

--- a/src/daria/corrections/shape/curvature.py
+++ b/src/daria/corrections/shape/curvature.py
@@ -68,6 +68,9 @@ class CurvatureCorrection:
                 in_meters (bool): returns True if width and height are given
                             in terms of meters. Only relevant if image
                             is provided.
+                use_cache (bool): flag controlling whether the tranformation
+                            map should be fetched from cache.
+                cache (Union[Path, str]): path to cached transformation map.
         """
 
         if config is not None:
@@ -116,6 +119,11 @@ class CurvatureCorrection:
 
         # Initialize cache for precomputed transformed coordinates
         self.cache = {}
+        self.use_cache = self.config.get("use_cache", False)
+        if self.use_cache:
+            self.cache_path = Path(
+                self.config.get("cache", "./cache/curvature_transformation.npy")
+            )
 
         # Hardcode the interpolation order, used when mapping pixels to transformed
         # coordinates
@@ -515,8 +523,20 @@ class CurvatureCorrection:
         assert isinstance(img, np.ndarray)
 
         # Precompute transformed coordinates based on self.config, if required.
-        if update_cache or "grid" not in self.cache:
+        if not (self.use_cache and self.cache_path.exists()) and (
+            update_cache or "grid" not in self.cache
+        ):
+
             self._precompute_transformed_coordinates(img)
+
+            # Store in cache
+            if self.use_cache:
+                np.save(self.cache_path, self.cache)
+
+        elif self.use_cache and self.cache_path.exists():
+
+            # Reache cache from file
+            self.cache = np.load(self.cache_path, allow_pickle=True).item()
 
         # Fetch precomputed transformed coordinates and the shape of the transformed image.
         grid = self.cache["grid"]


### PR DESCRIPTION
Allow caching of the curvature correction transformation to file. This is a small operation, when running an analysis once. However, on each initialization of an analysis, the transformation is recomputed. By caching, one just has to read from file. It has to be seen most as a comfort for code development than a necessary feature.