### PR TITLE
Hotfix: Specify interpolation method in resizing of label data.

### DIFF
--- a/src/daria/utils/segmentation.py
+++ b/src/daria/utils/segmentation.py
@@ -158,9 +158,16 @@ def segment(
 
     # ! ---- Postprocessing of the labels
 
+    labels_rescaled = _dilate_by_size(labels_rescaled, 1, False)
+    labels_rescaled = _dilate_by_size(labels_rescaled, 1, True)
+
     # Resize to oirginal size
     labels = skimage.img_as_ubyte(
-        skimage.transform.resize(labels_rescaled, img.shape[:2])
+        cv2.resize(
+            labels_rescaled,
+            tuple(reversed(img.shape[:2])),
+            interpolation=cv2.INTER_NEAREST,
+        )
     )
 
     if verbosity:


### PR DESCRIPTION
Label data is of type integer. When simpy using resize, to enlargen the image, interpolation is used by default creating new unwanted values. By fixing the interpolation method to the crude but here correct nearest neghbor routine, no artificial values are created. This in fact loosens the need (completely most likely) to use dilation in the geometry segmentation which is the current bottleneck of the segment routine.