### PR TITLE
Enhance typing and documentation, remove fluidflower references

### DIFF
--- a/src/darsia/image/image.py
+++ b/src/darsia/image/image.py
@@ -15,7 +15,7 @@ import math
 from datetime import datetime, timedelta
 from pathlib import Path
 from time import time as tm
-from typing import Any, Optional
+from typing import Any, Literal, Optional
 from warnings import warn
 
 import cv2
@@ -2182,7 +2182,9 @@ class OpticalImage(Image):
             self.img = img
             self.color_space = color_space.upper()
 
-    def to_monochromatic(self, key: str) -> ScalarImage:
+    def to_monochromatic(
+        self, key: Literal["gray", "red", "green", "blue", "hue", "saturation", "value"]
+    ) -> ScalarImage:
         """Returns monochromatic version of the image.
 
         Returns:
@@ -2228,6 +2230,12 @@ class OpticalImage(Image):
                 img = image.img[..., 1]
             elif key == "value":
                 img = image.img[..., 2]
+
+        else:
+            raise NotImplementedError(
+                f"""Key {key} not recognized. Please choose one of the following: """
+                """'gray', 'red', 'green', 'blue', 'hue', 'saturation', 'value'."""
+            )
 
         # Adapt specs.
         metadata = image.metadata()

--- a/src/darsia/presets/workflows/analysis/analysis_context.py
+++ b/src/darsia/presets/workflows/analysis/analysis_context.py
@@ -142,7 +142,7 @@ def prepare_analysis_context(
     also initialized and receives the restoration object.
 
     Args:
-        cls: FluidFlower rig class.
+        cls: Rig class.
         path: Path or list of paths to config files.
         all: Whether to use all images.
         use_facies: Whether to use facies as labels.

--- a/src/darsia/presets/workflows/analysis/analysis_cropping.py
+++ b/src/darsia/presets/workflows/analysis/analysis_cropping.py
@@ -92,7 +92,7 @@ def analysis_cropping(
     Note: If no options are set, the images are only read and no output is saved.
 
     Args:
-        cls: FluidFlower rig class.
+        cls: Rig class.
         path: Path or list of Paths to the images.
         show: Whether to show the images.
         save_jpg: Whether to save the images as JPG.

--- a/src/darsia/presets/workflows/analysis/analysis_fingers.py
+++ b/src/darsia/presets/workflows/analysis/analysis_fingers.py
@@ -151,7 +151,7 @@ def analysis_fingers(
     """Fingers analysis (standalone entry point).
 
     Args:
-        cls: FluidFlower rig class.
+        cls: Rig class.
         path: Path or list of paths to config files.
         show: Whether to show the images.
         all: Whether to use all images.

--- a/src/darsia/presets/workflows/analysis/analysis_mass.py
+++ b/src/darsia/presets/workflows/analysis/analysis_mass.py
@@ -216,7 +216,7 @@ def analysis_mass(
     """Mass analysis (standalone entry point).
 
     Args:
-        cls: FluidFlower rig class.
+        cls: Rig class.
         path: Path or list of paths to config files.
         show: Whether to show the images.
         all: Whether to use all images.

--- a/src/darsia/presets/workflows/analysis/analysis_segmentation.py
+++ b/src/darsia/presets/workflows/analysis/analysis_segmentation.py
@@ -73,7 +73,7 @@ def analysis_segmentation(
     """Segmentation analysis (standalone entry point).
 
     Args:
-        cls: FluidFlower rig class.
+        cls: Rig class.
         path: Path or list of paths to config files.
         show: Whether to show the images.
         all: Whether to use all images.

--- a/src/darsia/presets/workflows/analysis/analysis_volume.py
+++ b/src/darsia/presets/workflows/analysis/analysis_volume.py
@@ -214,7 +214,7 @@ def analysis_volume(
     """Volume analysis (standalone entry point).
 
     Args:
-        cls: FluidFlower rig class.
+        cls: Rig class.
         path: Path to config file.
         all: Whether to use all images.
         show: Whether to show the images.

--- a/src/darsia/presets/workflows/calibration/calibration_color_paths.py
+++ b/src/darsia/presets/workflows/calibration/calibration_color_paths.py
@@ -9,17 +9,18 @@ from matplotlib import pyplot as plt
 import darsia
 from darsia.presets.workflows.analysis.analysis_context import select_image_paths
 from darsia.presets.workflows.config.fluidflower_config import FluidFlowerConfig
+from darsia.presets.workflows.rig import Rig
 from darsia.presets.workflows.utils.images import load_images_with_cache
 from darsia.utils.standard_images import roi_to_mask
 
 logger = logging.getLogger(__name__)
 
 
-def calibration_color_paths(cls, path: Path, show: bool = False) -> None:
+def calibration_color_paths(cls: type[Rig], path: Path, show: bool = False) -> None:
     """Calibration of color paths for a given fluidflower class and configuration.
 
     Args:
-        cls: The fluidflower class to use (e.g., ffum.MuseumRig).
+        cls: Rig class.
         path: The path to the configuration file.
         show: Whether to display plots during processing.
 

--- a/src/darsia/presets/workflows/calibration/calibration_color_to_mass_analysis.py
+++ b/src/darsia/presets/workflows/calibration/calibration_color_to_mass_analysis.py
@@ -9,6 +9,7 @@ from darsia.presets.workflows.config.fluidflower_config import FluidFlowerConfig
 from darsia.presets.workflows.heterogeneous_color_to_mass_analysis import (
     HeterogeneousColorToMassAnalysis,
 )
+from darsia.presets.workflows.utils.images import load_images_with_cache
 
 logger = logging.getLogger(__name__)
 
@@ -62,25 +63,10 @@ def calibration_color_to_mass_analysis(
     if use_facies:
         # NOTE: Base analysis on facies (not labels)
         fluidflower.labels = fluidflower.facies.copy()
-        _color_paths = darsia.LabelColorPathMap.load(
-            config.color_paths.calibration_file
-        )
-        color_paths = darsia.LabelColorPathMap.refine(
-            _color_paths,
-            num_segments=6,
-            mode="relative",
-        )
+        color_paths = darsia.LabelColorPathMap.load(config.color_paths.calibration_file)
     else:
         # Use fine-grained but artificial labels for analysis
-        _color_paths = darsia.LabelColorPathMap.load(
-            config.color_paths.calibration_file
-        )
-
-        # ! ---- REFINE COLOR PATHS ----
-        color_paths = darsia.LabelColorPathMap.refine(
-            _color_paths,
-            num_segments=8,
-        )
+        color_paths = darsia.LabelColorPathMap.load(config.color_paths.calibration_file)
 
     # Pick a reference color path - merely for visualization
     reference_label = config.color_paths.reference_label
@@ -99,20 +85,13 @@ def calibration_color_to_mass_analysis(
         config, experiment, all=False, sub_config=config.color_to_mass
     )
 
-    # Store cached versions of calibration images to speed up development
-    calibration_images = []
-    if not default:
-        for p in calibration_image_paths:
-            if config.data.use_cache:
-                cache_path = config.data.cache / f"{p.stem}.npz"
-                if cache_path.exists():
-                    calibration_image = darsia.imread(cache_path)
-                else:
-                    calibration_image = fluidflower.read_image(p)
-                    calibration_image.save(cache_path)
-            else:
-                calibration_image = fluidflower.read_image(p)
-            calibration_images.append(calibration_image)
+    # Cache calibration images for performance
+    calibration_images: list[darsia.Image] = load_images_with_cache(
+        rig=fluidflower,
+        paths=calibration_image_paths,
+        use_cache=config.data.use_cache,
+        cache_dir=config.data.cache,
+    )
 
     # ! ---- ALLOCATE EMPTY INTERPOLATIONS ----
 
@@ -259,13 +238,26 @@ def calibration_color_to_mass_analysis(
         )
     else:
         # Start from scratch
-        signal_functions = {
-            label: darsia.PWTransformation(
-                color_paths[label].equidistant_distances,
-                color_path_interpolation[label].values,
-            )
-            for label in color_path_interpolation
-        }
+        signal_functions = {}
+        for label in color_path_interpolation:
+            if label in config.color_paths.ignore_labels or label in ignore_labels:
+                signal_functions[label] = darsia.PWTransformation(
+                    color_paths[reference_label].equidistant_distances,
+                    np.zeros(len(color_paths[reference_label].equidistant_distances)),
+                )
+                continue
+            try:
+                signal_functions[label] = darsia.PWTransformation(
+                    color_paths[label].equidistant_distances,
+                    color_path_interpolation[label].values,
+                )
+            except Exception as e:
+                signal_functions[label] = darsia.PWTransformation(
+                    color_paths[reference_label].equidistant_distances,
+                    np.zeros(len(color_paths[reference_label].equidistant_distances)),
+                )
+                ignore_labels.append(label)
+                logger.warning(f"Error processing label {label}: {e}")
         flash = darsia.SimpleFlash(
             min_value_aq=0,
             max_value_aq=0.75,

--- a/src/darsia/presets/workflows/calibration/calibration_flash.py
+++ b/src/darsia/presets/workflows/calibration/calibration_flash.py
@@ -56,13 +56,10 @@ def calibration_flash(cls, path: Path, show: bool = False):
         )
     calibration_images = []
     for p in calibration_image_paths:
-        if config.data.use_cache:
-            cache_path = config.data.cache / f"cache_{p.stem}.npz"
-            if cache_path.exists():
-                calibration_image = darsia.imread(cache_path)
-            else:
-                calibration_image = fluidflower.read_image(p)
-                calibration_image.save(cache_path)
+        cache_path = config.data.cache / f"{p.stem}.npz"
+        if not cache_path.exists():
+            calibration_image = fluidflower.read_image(p)
+            calibration_image.save(cache_path)
         else:
             calibration_image = fluidflower.read_image(p)
         calibration_images.append(calibration_image)

--- a/src/darsia/presets/workflows/setup/setup_rig.py
+++ b/src/darsia/presets/workflows/setup/setup_rig.py
@@ -23,7 +23,7 @@ def setup_rig(cls: Type[Rig], path: Path | list[Path], show: bool = False) -> No
     """Setup and store rig object.
 
     Args:
-        cls: Class of the rig to be setup, e.g. ffum.MuseumRig
+        cls: Class of the rig to be setup
         path (Path): Path to the config file.
         show (bool): Whether to show intermediate results.
 

--- a/src/darsia/presets/workflows/user_interface_analysis.py
+++ b/src/darsia/presets/workflows/user_interface_analysis.py
@@ -90,7 +90,7 @@ def print_help_for_flags(args, parser):
         sys.exit(0)
 
 
-def run_analysis(rig: type[Rig], args, **kwargs):
+def run_analysis(rig_cls: type[Rig], args, **kwargs):
     if not (
         args.cropping or args.mass or args.volume or args.segmentation or args.fingers
     ):
@@ -109,7 +109,7 @@ def run_analysis(rig: type[Rig], args, **kwargs):
 
     # Prepare shared context once for all analyses
     ctx = prepare_analysis_context(
-        cls=rig,
+        cls=rig_cls,
         path=args.config,
         all=args.all,
         use_facies=use_facies,
@@ -150,8 +150,8 @@ def run_analysis(rig: type[Rig], args, **kwargs):
         )
 
 
-def preset_analysis(rig: type[Rig], **kwargs):
+def preset_analysis(rig_cls: type[Rig], **kwargs):
     parser = build_parser_for_analysis()
     args = parser.parse_args()
     print_help_for_flags(args, parser)
-    run_analysis(rig, args, **kwargs)
+    run_analysis(rig_cls, args, **kwargs)

--- a/src/darsia/presets/workflows/user_interface_comparison.py
+++ b/src/darsia/presets/workflows/user_interface_comparison.py
@@ -45,7 +45,7 @@ def print_help_for_flags(args, parser):
         sys.exit(0)
 
 
-def run_comparison(rig: type[Rig], args, **kwargs):
+def run_comparison(rig_cls: type[Rig], args, **kwargs):
     # Only allow one option at a time
     assert (args.events + args.wasserstein_compute + args.wasserstein_assemble) == 1, (
         """Exactly one of events, wasserstein_compute, wasserstein_assemble, or """
@@ -63,21 +63,21 @@ def run_comparison(rig: type[Rig], args, **kwargs):
 
     if args.wasserstein_compute:
         comparison_wasserstein(
-            cls=Rig,
+            cls=rig_cls,
             path=args.config,
             compute=True,
         )
 
     if args.wasserstein_assemble:
         comparison_wasserstein(
-            cls=Rig,
+            cls=rig_cls,
             path=args.config,
             assemble=True,
         )
 
 
-def preset_comparison(rig: type[Rig], **kwargs):
+def preset_comparison(rig_cls: type[Rig], **kwargs):
     parser = build_parser_for_comparison()
     args = parser.parse_args()
     print_help_for_flags(args, parser)
-    run_comparison(rig, args, **kwargs)
+    run_comparison(rig_cls, args, **kwargs)

--- a/src/darsia/presets/workflows/utils/images.py
+++ b/src/darsia/presets/workflows/utils/images.py
@@ -2,15 +2,15 @@
 
 import logging
 from pathlib import Path
-from typing import Any
 
 import darsia
+from darsia.presets.workflows.rig import Rig
 
 logger = logging.getLogger(__name__)
 
 
 def load_images_with_cache(
-    rig: Any,
+    rig: Rig,
     paths: list[Path],
     use_cache: bool,
     cache_dir: Path | None,
@@ -31,7 +31,7 @@ def load_images_with_cache(
 
     Args:
         rig: Object exposing a ``read_image(path: Path) -> darsia.Image`` method
-            (e.g. a FluidFlower rig instance).
+            (e.g. Rig).
         paths: Ordered list of image paths to load.
         use_cache: Whether to use on-disk caching.
         cache_dir: Directory that holds (or will hold) the cached ``.npz`` files.

--- a/src/darsia/signals/color/color_path_regression.py
+++ b/src/darsia/signals/color/color_path_regression.py
@@ -263,8 +263,45 @@ class LabelColorPathMapRegression:
                     1.0,
                 ).reshape(self._shape + (3,))
 
-                # Plot the significant boxes
-                ax.voxels(color_spectrum_map[label].spectrum, facecolors=c_mesh)
+                # Use histogram values for alpha transparency
+                histogram = color_spectrum_map[label].histogram
+                # Normalize histogram to [0, 1] range for alpha values
+                alpha_mesh = np.zeros(self._shape, dtype=float)
+                hist_max = np.max(histogram[color_spectrum_map[label].spectrum])
+                if hist_max > 0:
+                    alpha_mesh = histogram / hist_max
+                else:
+                    alpha_mesh[color_spectrum_map[label].spectrum] = 1.0
+
+                # Block alpha into 10 discrete levels.
+                num_alpha_levels = 10
+                alpha_min = np.min(alpha_mesh)
+                alpha_max = np.max(alpha_mesh)
+                alpha_levels = np.linspace(alpha_min, alpha_max, num_alpha_levels)
+                alpha_blocked = (
+                    np.digitize(alpha_mesh, bins=alpha_levels) / num_alpha_levels
+                )
+                alpha_blocked = np.clip(alpha_blocked, alpha_min, alpha_max)
+
+                # Plot voxels for each alpha level separately
+                for alpha_level in alpha_levels:
+                    # Create mask for voxels at this alpha level
+                    alpha_tolerance = (alpha_max - alpha_min) / (2 * num_alpha_levels)
+                    mask_at_level = color_spectrum_map[label].spectrum & (
+                        np.abs(alpha_blocked - alpha_level) < alpha_tolerance
+                    )
+                    # Rescale such that levels span 0..1
+                    alpha_level_rescaled = (alpha_level - alpha_min) / (
+                        alpha_max - alpha_min
+                    )
+
+                    if np.any(mask_at_level):
+                        ax.voxels(
+                            mask_at_level,
+                            facecolors=c_mesh,
+                            alpha=alpha_level_rescaled,
+                        )
+
                 # Mark the ignored colors
                 if ignore is not None:
                     ax.voxels(

--- a/src/darsia/signals/models/color_path_interpolation.py
+++ b/src/darsia/signals/models/color_path_interpolation.py
@@ -2,12 +2,15 @@
 
 import abc
 import json
+import logging
 from pathlib import Path
 from typing import Literal, overload
 
 import numpy as np
 
 import darsia
+
+logger = logging.getLogger(__name__)
 
 
 class ColorPathFunction(darsia.Model):
@@ -143,6 +146,7 @@ class ColorPathInterpolation(ColorPathFunction):
         Returns:
             ColorPathInterpolation: Loaded ColorPathInterpolation instance.
         """
+        logger.info(f"Loading ColorPathInterpolation from {path}")
         with open(path.with_suffix(".json"), "r") as f:
             data = json.load(f)
         return ColorPathInterpolation.from_dict(data)


### PR DESCRIPTION
This pull request standardizes the terminology and type hints across multiple workflow modules by replacing references to "FluidFlower rig" or generic types with the more general and precise `Rig` class. This improves code clarity, consistency, and type safety throughout the codebase, especially in function signatures and docstrings related to rig-based workflows.

**Type hint and terminology standardization:**

* Updated function signatures and docstrings in analysis workflow modules (`analysis_context.py`, `analysis_cropping.py`, `analysis_fingers.py`, `analysis_mass.py`, `analysis_segmentation.py`, `analysis_volume.py`) to use `Rig` instead of "FluidFlower rig" or generic types for the `cls` argument. [[1]](diffhunk://#diff-54b624b82298aea6948005ac9f04d6c938b7836269e8cabe67a05802fafffcd8L145-R145) [[2]](diffhunk://#diff-72ebbe8d0d11f8f29a1f70d0733b8bbaff9410b435d895b0ab3da387bdc6460eL95-R95) [[3]](diffhunk://#diff-744fde591d18f5d4663d6688ad3780431780b121fc6cddb7894d2dc3f0e1ea8eL154-R154) [[4]](diffhunk://#diff-12222b812dd64ca52a00887ebbccaeae7914429ef3c06f4755008f95c80391c4L219-R219) [[5]](diffhunk://#diff-8c600e2fde7287608a4774b8e262bd27c873cd0ae5b2f5296042674dcd35c6eaL76-R76) [[6]](diffhunk://#diff-cd103f2b1696a191c5e06bc8171a78e5ce3f02da1848bc90321f482272f74f59L217-R217)
* Modified calibration and utility modules (`calibration_color_paths.py`, `utils/images.py`) to use explicit `Rig` type hints and updated docstrings accordingly. [[1]](diffhunk://#diff-bc272716e062fa670c081117b5365d0715f9303f7a6ff96c50e18e7e41bca3e4R12-R23) [[2]](diffhunk://#diff-e6cc0ee8175cc70501155f45669f86f5c025faa676e409b444fdd350abdc863aL5-R13) [[3]](diffhunk://#diff-e6cc0ee8175cc70501155f45669f86f5c025faa676e409b444fdd350abdc863aL34-R34)

**User interface and workflow orchestration improvements:**

* Renamed function arguments from `rig` to `rig_cls` in user interface modules (`user_interface_analysis.py`, `user_interface_comparison.py`) for clarity, and updated all relevant function calls. [[1]](diffhunk://#diff-26c12ecf8dd8c80eaedfa7aed9de743ebc2af9bfaeb0d53974c50ea68ee31a33L93-R93) [[2]](diffhunk://#diff-26c12ecf8dd8c80eaedfa7aed9de743ebc2af9bfaeb0d53974c50ea68ee31a33L112-R112) [[3]](diffhunk://#diff-26c12ecf8dd8c80eaedfa7aed9de743ebc2af9bfaeb0d53974c50ea68ee31a33L153-R157) [[4]](diffhunk://#diff-7550171b531d7fbfcb9962dfe624807b94fc136fa48ce01d55812916938d082eL48-R48) [[5]](diffhunk://#diff-7550171b531d7fbfcb9962dfe624807b94fc136fa48ce01d55812916938d082eL66-R83)
* Updated the `setup_rig` function's docstring to generalize the rig class argument.