### PR TITLE
Add sanity check for improved reliability

### DIFF
--- a/src/darsia/presets/workflows/rig.py
+++ b/src/darsia/presets/workflows/rig.py
@@ -508,6 +508,9 @@ class Rig:
                 sample_groups.append(samples)
             else:
                 for label in config.labels:
+                    assert (
+                        label in self.labels.img
+                    ), f"Label {label} not found in labels image."
                     mask = self.labels.img == label
                     samples = illumination_correction.select_random_samples(
                         mask=mask, config=config


### PR DESCRIPTION
This pull request adds a validation step to the `setup_illumination_correction` function to ensure that each label specified in the configuration exists in the labels image before proceeding. This helps catch configuration errors early and prevents downstream issues.

Validation improvements:

* Added an assertion that checks whether each `label` in `config.labels` is present in `self.labels.img`, raising an error if not.