### PR TITLE
Prevent protocol setup for 'all' option

### DIFF
--- a/src/darsia/presets/workflows/user_interface_gui.py
+++ b/src/darsia/presets/workflows/user_interface_gui.py
@@ -462,10 +462,10 @@ def _run_setup_workflow(
         segment_colored_image(paths, show=show)
     if options["all"] or options["facies"]:
         setup_facies(rig_cls, paths, show=show)
-    if options["all"] or options["protocol"]:
-        setup_imaging_protocol(paths, force=options["force"], show=show)
     if options["all"] or options["rig"]:
         setup_rig(rig_cls, paths, show=show)
+    if options["protocol"]:
+        setup_imaging_protocol(paths, force=options["force"], show=show)
     if options["delete_rig"]:
         delete_rig(rig_cls, paths, show=show)
 
@@ -1391,7 +1391,7 @@ class WorkflowGUI:
             "show": self.setup_show.get(),
             "force": False,
         }
-        protocol_enabled = options["all"] or options["protocol"]
+        protocol_enabled = options["protocol"]
         if protocol_enabled:
             from darsia.presets.workflows.setup.setup_protocols import (
                 preview_protocol_setup_conflicts,

--- a/src/darsia/presets/workflows/user_interface_setup.py
+++ b/src/darsia/presets/workflows/user_interface_setup.py
@@ -86,9 +86,9 @@ def preset_setup(rig=Rig):
         segment_colored_image(args.config, args.show)
     if args.all or args.facies:
         setup_facies(rig, args.config, args.show)
-    if args.all or args.protocol:
-        setup_imaging_protocol(args.config, force=args.force, show=args.show)
     if args.all or args.rig:
         setup_rig(rig, args.config, args.show)
+    if args.protocol:
+        setup_imaging_protocol(args.config, force=args.force, show=args.show)
     if args.delete:
         delete_rig(rig, args.config, args.show)


### PR DESCRIPTION
This pull request refines how the imaging protocol setup is triggered in the user interface and setup workflows. The main change is that the imaging protocol is now only set up when the `protocol` option is explicitly selected, rather than being included when `all` options are selected. This change ensures more precise control over which setup steps are executed.

**Workflow logic changes:**

* In `user_interface_gui.py`, the call to `setup_imaging_protocol` in `_run_setup_workflow` is now only made if the `protocol` option is set, not when `all` is set.
* In `user_interface_setup.py`, the call to `setup_imaging_protocol` in `preset_setup` is similarly restricted to only when the `protocol` option is set.

**User interface behavior:**

* In `_run_setup_clicked`, the `protocol_enabled` flag is now only true if the `protocol` option is selected, not when `all` is selected.