### PR TITLE
Fix flash tuning format issue

### DIFF
--- a/src/darsia/presets/workflows/heterogeneous_color_to_mass_analysis.py
+++ b/src/darsia/presets/workflows/heterogeneous_color_to_mass_analysis.py
@@ -1998,17 +1998,17 @@ class HeterogeneousColorToMassAnalysis:
                             signal_function_scatter.set_offsets(np.c_[x_vals, y_vals])
 
                         # Update flash cut-off and max value lines
-                        signal_function_aq_max_y.set_ydata(self.flash.max_value_aq)
-                        signal_function_g_max_y.set_ydata(self.flash.max_value_g)
-                        signal_function_g_min_y.set_ydata(self.flash.min_value_g)
+                        signal_function_aq_max_y.set_ydata([self.flash.max_value_aq])
+                        signal_function_g_max_y.set_ydata([self.flash.max_value_g])
+                        signal_function_g_min_y.set_ydata([self.flash.min_value_g])
                         aq_max_x = signal_func.inverse(self.flash.max_value_aq)
                         aq_min_x = signal_func.inverse(self.flash.min_value_aq)
                         g_max_x = signal_func.inverse(self.flash.max_value_g)
                         g_min_x = signal_func.inverse(self.flash.min_value_g)
-                        signal_function_aq_max_x.set_xdata(aq_max_x)
-                        signal_function_aq_min_x.set_xdata(aq_min_x)
-                        signal_function_g_max_x.set_xdata(g_max_x)
-                        signal_function_g_min_x.set_xdata(g_min_x)
+                        signal_function_aq_max_x.set_xdata([aq_max_x])
+                        signal_function_aq_min_x.set_xdata([aq_min_x])
+                        signal_function_g_max_x.set_xdata([g_max_x])
+                        signal_function_g_min_x.set_xdata([g_min_x])
 
                         # Update the position of the annotaion
                         ax_signal_function.texts[0].set_position(
@@ -2338,17 +2338,17 @@ class HeterogeneousColorToMassAnalysis:
                         signal_function_scatter.set_offsets(np.c_[x_vals, y_vals])
 
                         # Update flash cut-off and max value lines
-                        signal_function_aq_max_y.set_ydata(self.flash.max_value_aq)
-                        signal_function_g_max_y.set_ydata(self.flash.max_value_g)
-                        signal_function_g_min_y.set_ydata(self.flash.min_value_g)
+                        signal_function_aq_max_y.set_ydata([self.flash.max_value_aq])
+                        signal_function_g_max_y.set_ydata([self.flash.max_value_g])
+                        signal_function_g_min_y.set_ydata([self.flash.min_value_g])
                         aq_max_x = signal_func.inverse(self.flash.max_value_aq)
                         aq_min_x = signal_func.inverse(self.flash.min_value_aq)
                         g_max_x = signal_func.inverse(self.flash.max_value_g)
                         g_min_x = signal_func.inverse(self.flash.min_value_g)
-                        signal_function_aq_max_x.set_xdata(aq_max_x)
-                        signal_function_aq_min_x.set_xdata(aq_min_x)
-                        signal_function_g_max_x.set_xdata(g_max_x)
-                        signal_function_g_min_x.set_xdata(g_min_x)
+                        signal_function_aq_max_x.set_xdata([aq_max_x])
+                        signal_function_aq_min_x.set_xdata([aq_min_x])
+                        signal_function_g_max_x.set_xdata([g_max_x])
+                        signal_function_g_min_x.set_xdata([g_min_x])
 
                         # Update the position of the annotaion
                         ax_signal_function.texts[0].set_position(


### PR DESCRIPTION
This pull request updates how line data is set for several matplotlib plot elements in the `heterogeneous_color_to_mass_analysis.py` workflow. The main change is to ensure that y-data and x-data are always provided as lists, improving compatibility with matplotlib's API and preventing potential errors when updating plots.

**Plot update improvements:**

* Updated calls to `set_ydata` and `set_xdata` for lines such as `signal_function_aq_max_y`, `signal_function_g_max_y`, etc., to always pass values as single-element lists instead of scalars in both the `update_analysis` and `next_label` functions. This ensures consistent and correct behavior when updating plot lines. [[1]](diffhunk://#diff-bd062717de80856eb28a32288b0b85324d4d78e071a12414744f722b678e982bL2001-R2011) [[2]](diffhunk://#diff-bd062717de80856eb28a32288b0b85324d4d78e071a12414744f722b678e982bL2341-R2351)