### PR TITLE
Fix division by zero error handling

### DIFF
--- a/src/darsia/signals/color/color_path.py
+++ b/src/darsia/signals/color/color_path.py
@@ -161,11 +161,14 @@ class ColorPath:
         if self.mode == "rgb":
             color_list = []
             # Normalize the values to the range [0, 1]
-            normalized_values = [
-                (v - min(self.relative_distances))
-                / (max(self.relative_distances) - min(self.relative_distances))
-                for v in self.relative_distances
-            ]
+            if min(self.relative_distances) == max(self.relative_distances):
+                normalized_values = [0.0 for _ in self.relative_distances]
+            else:
+                normalized_values = [
+                    (v - min(self.relative_distances))
+                    / (max(self.relative_distances) - min(self.relative_distances))
+                    for v in self.relative_distances
+                ]
             for i in range(n_colors):
                 ratio = i / (n_colors - 1)
                 index = np.searchsorted(normalized_values, ratio)


### PR DESCRIPTION
This pull request improves the robustness of the `sample_absolute_color_path` method in `color_path.py` by handling the case where all relative distances are equal, preventing a division by zero error during normalization.

Error handling enhancement:

* Added a check to set all normalized values to `0.0` when `min(self.relative_distances)` equals `max(self.relative_distances)`, ensuring safe normalization and avoiding division by zero.