### PR TITLE
Fix min and max values to align with full cmap

### DIFF
--- a/src/darsia/signals/color/color_path_regression.py
+++ b/src/darsia/signals/color/color_path_regression.py
@@ -1761,21 +1761,12 @@ class LabelColorPathMapRegression:
                 )
 
                 if preview_signal is not None:
-                    finite_preview = np.isfinite(preview_signal)
-                    if np.any(finite_preview):
-                        vmin = float(np.nanmin(preview_signal))
-                        vmax = float(np.nanmax(preview_signal))
-                        if np.isclose(vmin, vmax):
-                            vmin -= preview_signal_limits_epsilon
-                            vmax += preview_signal_limits_epsilon
-                    else:
-                        vmin, vmax = 0.0, 1.0
                     preview_cmap = build_current_color_path().get_color_map()
                     ax_preview_interpretation.imshow(
                         preview_signal,
                         cmap=preview_cmap,
-                        vmin=vmin,
-                        vmax=vmax,
+                        vmin=0,
+                        vmax=1,
                     )
                     title = "Native pH indicator interpretation"
                     if preview_signal_is_stale:

--- a/src/darsia/signals/color/color_path_regression.py
+++ b/src/darsia/signals/color/color_path_regression.py
@@ -1585,7 +1585,6 @@ class LabelColorPathMapRegression:
         has_preview_data = (
             label is not None and preview_baseline is not None and preview_shape_matches
         )
-        preview_signal_limits_epsilon = 1e-8
         min_preview_rows = 120
         mask_interpolation_threshold = 0.5
         preview_downsampling_factor = 4


### PR DESCRIPTION
This pull request simplifies how the preview signal is visualized in the `redraw` method of `color_path_regression.py`. Instead of dynamically calculating the color scale limits based on the data, the visualization now always uses a fixed range from 0 to 1.

Visualization changes:

* The logic for computing `vmin` and `vmax` from the actual data in `preview_signal` was removed. The color mapping for the preview is now always set to `vmin=0` and `vmax=1`, regardless of the data values.