### PR TITLE
Use canonical folder name for consistency

### DIFF
--- a/src/darsia/presets/workflows/analysis/analysis_cropping.py
+++ b/src/darsia/presets/workflows/analysis/analysis_cropping.py
@@ -53,7 +53,7 @@ def analysis_cropping_from_context(
         )
 
     # ! ---- CROPPING ----
-    plot_folder = ctx.config.data.results / "cropped_images"
+    plot_folder = ctx.config.data.results / "cropping"
     plot_folder.mkdir(parents=True, exist_ok=True)
 
     for path in ctx.image_paths:

--- a/src/darsia/presets/workflows/user_interface_gui.py
+++ b/src/darsia/presets/workflows/user_interface_gui.py
@@ -268,7 +268,7 @@ def suggested_analysis_results_folder(
 
     mode = mode_actions[0]
     if mode == "cropping":
-        return results / "cropped_images"
+        return results / "cropping"
 
     analysis = merged.get("analysis")
     if isinstance(analysis, dict):

--- a/tests/unit/test_user_interface_gui.py
+++ b/tests/unit/test_user_interface_gui.py
@@ -215,7 +215,7 @@ def test_suggested_analysis_results_folder_for_cropping(tmp_path: Path) -> None:
     config.write_text(f"[data]\nresults = '{results}'\n")
 
     folder = suggested_analysis_results_folder([config], ["cropping"])
-    assert folder == results / "cropped_images"
+    assert folder == results / "cropping"
 
 
 def test_suggested_analysis_results_folder_from_analysis_section(


### PR DESCRIPTION
This pull request standardizes the naming of the results folder for cropping operations across the codebase. The folder name is updated from `cropped_images` to `cropping` to ensure consistency in workflow logic, user interface, and tests.

Folder naming consistency:

* Changed the output directory for cropping results from `cropped_images` to `cropping` in the main analysis workflow (`src/darsia/presets/workflows/analysis/analysis_cropping.py`).
* Updated the suggested results folder in the GUI logic to use `cropping` instead of `cropped_images` (`src/darsia/presets/workflows/user_interface_gui.py`).
* Modified the related unit test to expect the new folder name `cropping` (`tests/unit/test_user_interface_gui.py`).