### PR TITLE
Enrich finger statistics

### DIFF
--- a/src/darsia/presets/workflows/analysis/analysis_fingers.py
+++ b/src/darsia/presets/workflows/analysis/analysis_fingers.py
@@ -345,6 +345,12 @@ def analysis_fingers_from_context(
                         {
                             "x": float(x),
                             "travel_distance": float(travel_distance),
+                            "speed": float(speeds[-1]) if speeds else float("nan"),
+                            "vertical_speed": (
+                                float(vertical_speeds[-1])
+                                if vertical_speeds
+                                else float("nan")
+                            ),
                         }
                     )
 
@@ -367,6 +373,13 @@ def analysis_fingers_from_context(
                     float(finger["travel_distance"]) for finger in active_fingers
                 ]
 
+                # Compute the velocities of active fingers at this time
+                # (using the last velocity before or at this time).
+                speeds_at_time = [finger["speed"] for finger in active_fingers]
+                speeds_y_at_time = [
+                    finger["vertical_speed"] for finger in active_fingers
+                ]
+
                 # Count new fingers that have zero travel distance at this time
                 # (i.e., just appeared).
                 new_fingers = int(
@@ -379,6 +392,8 @@ def analysis_fingers_from_context(
                 statistics[time] = {
                     "horizontal_distances": dist_x,
                     "travel_distances": travel_distances_at_time,
+                    "finger_speeds": speeds_at_time,
+                    "finger_vertical_speeds": speeds_y_at_time,
                     "new_fingers": new_fingers,
                     "number_fingers": len(active_fingers),
                     "contour_length": contour_length,


### PR DESCRIPTION
This pull request enhances the analysis of finger dynamics in the `analysis_fingers_from_context` workflow by adding tracking and reporting of both horizontal and vertical finger speeds. These changes provide more detailed velocity information for each finger at every time step, improving the granularity of the analysis.

**Enhancements to finger speed tracking and reporting:**

* Added storage of the latest horizontal (`speed`) and vertical (`vertical_speed`) speeds for each finger in the finger state dictionary.
* At each time step, computed and stored lists of current horizontal and vertical speeds for all active fingers (`speeds_at_time` and `speeds_y_at_time`).
* Updated the per-time-step `statistics` dictionary to include the new `finger_speeds` and `finger_vertical_speeds` fields, making this velocity data available for downstream analysis.