### PR TITLE
Apply Black code style formatting

### DIFF
--- a/src/darsia/presets/workflows/analysis/analysis_segmentation.py
+++ b/src/darsia/presets/workflows/analysis/analysis_segmentation.py
@@ -14,9 +14,7 @@ from darsia.presets.workflows.analysis.scalar_products import (
     analysis_scalar_products,
     requires_rescaled_modes,
 )
-from darsia.presets.workflows.analysis.streaming import (
-    publish_stream_images,
-)
+from darsia.presets.workflows.analysis.streaming import publish_stream_images
 from darsia.presets.workflows.rig import Rig
 from darsia.presets.workflows.segmentation_contours import SegmentationContours
 

--- a/src/darsia/presets/workflows/config/data_registry.py
+++ b/src/darsia/presets/workflows/config/data_registry.py
@@ -48,12 +48,7 @@ import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from .time_data import (
-    ImagePathData,
-    ImageTimeData,
-    ImageTimeIntervalData,
-    TimeData,
-)
+from .time_data import ImagePathData, ImageTimeData, ImageTimeIntervalData, TimeData
 
 logger = logging.getLogger(__name__)
 

--- a/src/darsia/presets/workflows/rig.py
+++ b/src/darsia/presets/workflows/rig.py
@@ -19,9 +19,7 @@ from darsia.presets.workflows.config.corrections import (
 )
 from darsia.presets.workflows.config.image_porosity import ImagePorosityConfig
 from darsia.presets.workflows.facies_props import FaciesProps
-from darsia.presets.workflows.setup.illustrations import (
-    save_scalar_map_illustration,
-)
+from darsia.presets.workflows.setup.illustrations import save_scalar_map_illustration
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull request primarily makes minor code style improvements by consolidating multi-line import statements into single-line imports across several files. These changes help to simplify and clean up the import sections, making the code more concise and readable.

Import statement simplifications:

* Changed multi-line import of `publish_stream_images` to a single line in `analysis_segmentation.py`.
* Changed multi-line import of several classes from `.time_data` to a single line in `data_registry.py`.
* Changed multi-line import of `save_scalar_map_illustration` to a single line in `rig.py`.