### PR TITLE
Fix handling of badly formatted paths

### DIFF
--- a/src/darsia/image/imread.py
+++ b/src/darsia/image/imread.py
@@ -270,7 +270,20 @@ def _read_single_optical_image(path: Path) -> tuple[np.ndarray, Optional[datetim
 
     """
     # Read image and convert to RGB and float ([0,1])
-    array = cv2.cvtColor(cv2.imread(str(path), cv2.IMREAD_UNCHANGED), cv2.COLOR_BGR2RGB)
+    try:
+        array = cv2.cvtColor(
+            cv2.imread(str(path), cv2.IMREAD_UNCHANGED), cv2.COLOR_BGR2RGB
+        )
+    except Exception:
+        img_bytes = np.fromfile(str(path), np.uint8)
+        if img_bytes.size == 0:
+            raise FileNotFoundError(f"Could not read file: {path}")
+
+        # Let darsia.imread handle the transformations if possible,
+        # or apply corrections manually
+        array = cv2.cvtColor(
+            cv2.imdecode(img_bytes, cv2.IMREAD_COLOR), cv2.COLOR_BGR2RGB
+        )
 
     # Prefered: Read time from exif metafile.
     pil_img = PIL_Image.open(path)


### PR DESCRIPTION
This pull request improves the robustness of image reading in the `_read_single_optical_image` function by adding error handling for cases where images cannot be read using the standard OpenCV method. If the initial read fails, the code now attempts to read the image from raw bytes and decodes it, ensuring better handling of problematic or non-standard image files.

**Image reading robustness improvements:**

* Enhanced `_read_single_optical_image` in `imread.py` to handle exceptions during image reading with OpenCV. If the standard method fails, the function now reads the image as raw bytes and decodes it, raising a `FileNotFoundError` if the file cannot be read. This makes the function more reliable for various image formats and corrupted files.