### PR TITLE
Allow video processing for non-conforming data

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,16 +14,14 @@ requires-python = ">=3.10"
 keywords = ["darcy", "image analysis", "porous media", "flow"]
 
 authors = [
-  { name = "Jakub Wiktor Both",  email = "jakub.both@uib.no" },
+  { name = "Jakub Wiktor Both", email = "jakub.both@uib.no" },
   { name = "Trygve Tegnander" },
   { name = "Enrico Facca" },
   { name = "Erlend Storvik" },
   { name = "Jan Martin Nordbotten" },
 ]
 
-maintainers = [
-  { name = "Jakub Wiktor Both", email = "jakub.both@uib.no" },
-]
+maintainers = [{ name = "Jakub Wiktor Both", email = "jakub.both@uib.no" }]
 
 classifiers = [
   "Development Status :: 3 - Alpha",
@@ -38,6 +36,7 @@ classifiers = [
 ]
 
 dependencies = [
+  "natsort",
   "numpy",
   "opencv-python",
   "scipy",
@@ -59,9 +58,9 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage    = "https://github.com/pmgbergen/DarSIA"
-Repository  = "https://github.com/pmgbergen/DarSIA.git"
-Issues      = "https://github.com/pmgbergen/DarSIA/issues"
+Homepage = "https://github.com/pmgbergen/DarSIA"
+Repository = "https://github.com/pmgbergen/DarSIA.git"
+Issues = "https://github.com/pmgbergen/DarSIA/issues"
 
 # ── Optional dependencies (replaces extras_require in setup.py) ───────────────
 [project.optional-dependencies]

--- a/src/darsia/presets/workflows/config/video.py
+++ b/src/darsia/presets/workflows/config/video.py
@@ -37,10 +37,13 @@ def _to_rgb(color: list[int] | tuple[int, int, int], name: str) -> tuple[int, in
 class VideoSourceConfig:
     folder: Path | None = None
     pattern: str | None = None
-    recursive: bool = False
     extensions: list[str] = field(
         default_factory=lambda: [".jpg", ".jpeg", ".png", ".bmp", ".tif", ".tiff"]
     )
+    recursive: bool = False
+    sorting: str = "protocol"
+
+    ALLOWED_SORTING_METHODS = {"protocol", "name"}
 
     def load(self, sec: dict) -> "VideoSourceConfig":
         src = _get_key(sec, "source", required=True)
@@ -53,6 +56,7 @@ class VideoSourceConfig:
             _get_key(src, "extensions", required=False, default=self.extensions)
         )
         self.recursive = bool(_get_key(src, "recursive", required=False, default=False))
+        self.sorting = _get_key(src, "sorting", required=False, default=self.sorting)
         return self
 
 

--- a/src/darsia/presets/workflows/utils/utils_media.py
+++ b/src/darsia/presets/workflows/utils/utils_media.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import logging
 from datetime import datetime
 from pathlib import Path
+from typing import Literal
 
 import cv2
 import numpy as np
+from natsort import natsorted, ns
 from PIL import Image as PILImage
 
 import darsia
@@ -46,24 +48,41 @@ def _scan_source_images(
 
 
 def _protocol_sort_frames(
-    experiment: darsia.ProtocolledExperiment, image_paths: list[Path]
+    experiment: darsia.ProtocolledExperiment,
+    image_paths: list[Path],
+    sorting_method: Literal["protocol", "name"],
 ) -> list[tuple[Path, datetime, float]]:
-    rows: list[tuple[Path, datetime, float]] = []
-    if hasattr(experiment, "iter_available"):
-        for _, path, dt in experiment.iter_available(image_paths):
-            elapsed_time_h = experiment.time_since_start(dt)
-            rows.append((path, dt, elapsed_time_h))
-    else:
-        for path in image_paths:
-            try:
-                if experiment.is_blacklisted(path):
+    if sorting_method == "name":
+        # Sort by filename only, ignoring protocol datetimes and blacklisting.
+        # Elapsed time is set to 0.
+        rows = [(path, None, 0) for path in natsorted(image_paths, alg=ns.IGNORECASE)]
+    elif sorting_method == "protocol":
+        rows: list[tuple[Path, datetime, float]] = []
+        if (
+            hasattr(experiment, "iter_available")
+            and len(experiment.iter_available(image_paths)) > 0
+        ):
+            for _, path, dt in experiment.iter_available(image_paths):
+                print(path, dt)
+                elapsed_time_h = experiment.time_since_start(dt)
+                rows.append((path, dt, elapsed_time_h))
+        else:
+            for path in image_paths:
+                print(path)
+                try:
+                    if experiment.is_blacklisted(path):
+                        continue
+                    dt = experiment.get_datetime(path)
+                except ValueError:
                     continue
-                dt = experiment.get_datetime(path)
-            except ValueError:
-                continue
-            elapsed_time_h = experiment.time_since_start(dt)
-            rows.append((path, dt, elapsed_time_h))
-    rows.sort(key=lambda item: item[1])
+                elapsed_time_h = experiment.time_since_start(dt)
+                rows.append((path, dt, elapsed_time_h))
+            rows.sort(key=lambda item: item[1])
+    else:
+        raise ValueError(
+            f"Unsupported video source sorting method: '{sorting_method}'. "
+            "Supported methods: 'protocol', 'name'."
+        )
     return rows
 
 
@@ -216,7 +235,9 @@ def build_media(path: Path | list[Path]) -> dict[str, Path]:
     )
     if not source_paths:
         raise FileNotFoundError(f"No source images found in '{source_folder}'.")
-    ordered = _protocol_sort_frames(experiment, source_paths)
+    ordered = _protocol_sort_frames(
+        experiment, source_paths, config.video.source.sorting
+    )
     if not ordered:
         raise ValueError(
             "No source images could be matched to the imaging protocol (or all were "

--- a/tests/unit/test_video_config_and_media_utils.py
+++ b/tests/unit/test_video_config_and_media_utils.py
@@ -109,7 +109,7 @@ def test_protocol_sort_frames_filters_blacklist_and_invalid_and_sorts() -> None:
         Path("noise.png"),
         Path("img_00003.png"),
     ]
-    ordered = _protocol_sort_frames(exp, paths)
+    ordered = _protocol_sort_frames(exp, paths, "protocol")
     assert [p.name for p, _, _ in ordered] == ["img_00002.png", "img_00004.png"]
     assert [round(elapsed, 2) for _, _, elapsed in ordered] == [2.0, 4.0]
 


### PR DESCRIPTION
This pull request adds support for configurable image sorting methods in the video source configuration, allowing users to choose between protocol-based and filename-based sorting. It updates both the configuration and the image scanning logic to support this new feature, and ensures that the sorting method is validated and properly applied.

**Video source configuration enhancements:**
* Added a new `sorting` field to the `VideoSourceConfig` class, with allowed values `"protocol"` and `"name"`, and updated the `load` method to read this value from the configuration. [[1]](diffhunk://#diff-05a60354351b72a579eabe14162ad7105851fa8a444abd6a28c7fc29cf725f30L40-R46) [[2]](diffhunk://#diff-05a60354351b72a579eabe14162ad7105851fa8a444abd6a28c7fc29cf725f30R59)
* Defined `ALLOWED_SORTING_METHODS` in `VideoSourceConfig` to restrict valid sorting options.

**Image sorting logic updates:**
* Modified `_protocol_sort_frames` to accept a `sorting_method` parameter and implement sorting by filename (using `natsorted`) or by protocol, raising an error for unsupported methods. [[1]](diffhunk://#diff-4be16b068e8fe5006ea77c218d8854acffcfa987b342beedea0a7edc224ea7d3L49-R71) [[2]](diffhunk://#diff-4be16b068e8fe5006ea77c218d8854acffcfa987b342beedea0a7edc224ea7d3R81-R85)
* Updated `build_media` to pass the configured sorting method from `config.video.source.sorting` to `_protocol_sort_frames`.

**Dependency and import changes:**
* Added imports for `Literal` and `natsort` to support type checking and natural sorting by filename.…protocol