### PR TITLE
Enhance hue check for improved safety

### DIFF
--- a/src/darsia/presets/workflows/mode_resolution.py
+++ b/src/darsia/presets/workflows/mode_resolution.py
@@ -99,7 +99,7 @@ def _normalized_trichromatic(
     elif cs in {"HSV", "HLS"}:
         # OpenCV conventions differ by dtype; normalize all channels to [0, 1].
         hue = arr[..., 0]
-        hue_scale = 360.0 if np.max(hue) > 180.0 else 180.0
+        hue_scale = 360.0 if np.max(hue) > 180.0 and np.min(hue) >= 0.0 else 180.0
         arr[..., 0] = hue / hue_scale
         if np.max(arr[..., 1:]) > 1.0:
             arr[..., 1:] = arr[..., 1:] / 255.0


### PR DESCRIPTION
This pull request makes a targeted fix to the normalization logic for hue values in the `_normalized_trichromatic` function, specifically for HSV and HLS color spaces. The update ensures that hue scaling only uses 360.0 when all hue values are non-negative and the maximum exceeds 180, which improves the robustness of color normalization.

Color normalization fix:

* Updated the hue scaling logic in `_normalized_trichromatic` within `src/darsia/presets/workflows/mode_resolution.py` to check that the minimum hue value is non-negative before using a scale of 360.0. This prevents incorrect normalization when hue values are negative.