### PR TITLE
Enable CSV and Excel setup for facies

### DIFF
--- a/src/darsia/presets/workflows/setup/setup_facies.py
+++ b/src/darsia/presets/workflows/setup/setup_facies.py
@@ -44,7 +44,10 @@ def setup_facies(cls: Rig, path: Path, show: bool = False):
     facies = darsia.reassign_labels(labels, label_to_facies_map)
 
     # Sanity check - ids. Check that all facies ids are defined in props.
-    facies_props = pd.read_excel(config.facies.props)
+    if config.facies.props.suffix == ".xlsx":
+        facies_props = pd.read_excel(config.facies.props)
+    elif config.facies.props.suffix == ".csv":
+        facies_props = pd.read_csv(config.facies.props)
     facies_ids = facies_props["id"].tolist()
     for facies_id in np.unique(facies.img):
         assert (


### PR DESCRIPTION
This pull request improves the flexibility of the facies setup workflow by allowing facies property files to be loaded from both Excel and CSV formats, instead of only supporting Excel files previously.

**Facies properties file loading:**

* Updated `setup_facies` in `setup_facies.py` to support loading facies properties from `.csv` files using `pandas.read_csv`, in addition to `.xlsx` files with `pandas.read_excel`.