### PR TITLE
Generalize calibration methods using AnalysisContext

### DIFF
--- a/src/darsia/presets/workflows/analysis/analysis_context.py
+++ b/src/darsia/presets/workflows/analysis/analysis_context.py
@@ -105,6 +105,8 @@ class AnalysisContext:
     color_embedding_runtime: ColorEmbeddingRuntime | None = None
 
 
+# NOTE: Used in multiple places (not only analysis).
+# Should be moved and made more robust in terms of output.
 def select_image_paths(
     config: FluidFlowerConfig,
     experiment: darsia.ProtocolledExperiment,
@@ -239,6 +241,9 @@ def prepare_analysis_context(
     path: Path | list[Path],
     all: bool = False,
     require_color_to_mass: bool = False,
+    section: str | None = "analysis",
+    require_results: bool = True,
+    require_data: bool = True,
 ) -> AnalysisContext:
     """Prepare common analysis context.
 
@@ -259,8 +264,10 @@ def prepare_analysis_context(
 
     """
     # ! ---- LOAD CONFIG ----
-    config = FluidFlowerConfig(path, require_results=True, require_data=True)
-    config.check("analysis", "protocol", "data", "rig")
+    config = FluidFlowerConfig(
+        path, require_results=require_results, require_data=require_data
+    )
+    config.check(section, "protocol", "data", "rig")
 
     # Mypy type checking
     assert config.rig is not None
@@ -277,11 +284,19 @@ def prepare_analysis_context(
     fluidflower.load_experiment(experiment)
 
     # ! ---- SELECT IMAGE PATHS ----
+
+    if section == "calibration" and config.calibration is not None:
+        sub_config = config.calibration
+    elif section == "analysis" and config.analysis is not None:
+        sub_config = config.analysis
+    else:
+        sub_config = None
+
     image_paths = select_image_paths(
         config,
         experiment,
         all=all,
-        sub_config=config.analysis,
+        sub_config=sub_config,
         data_registry=config.data.registry,
     )
 

--- a/src/darsia/presets/workflows/calibration/calibration_color_paths.py
+++ b/src/darsia/presets/workflows/calibration/calibration_color_paths.py
@@ -7,11 +7,13 @@ import numpy as np
 from matplotlib import pyplot as plt
 
 import darsia
-from darsia.presets.workflows.analysis.analysis_context import select_image_paths
+from darsia.presets.workflows.analysis.analysis_context import (
+    AnalysisContext,
+    select_image_paths,
+)
 from darsia.presets.workflows.basis import label_ids_from_image
 from darsia.presets.workflows.calibration.metadata import write_calibration_metadata
 from darsia.presets.workflows.config.fluidflower_config import FluidFlowerConfig
-from darsia.presets.workflows.rig import Rig
 from darsia.presets.workflows.utils.images import load_images_with_cache
 from darsia.presets.workflows.utils.roi_visualization import draw_active_region
 from darsia.signals.color import ColorPathEmbedding
@@ -20,7 +22,9 @@ from darsia.utils.standard_images import roi_to_mask
 logger = logging.getLogger(__name__)
 
 
-def calibration_color_paths(cls: type[Rig], path: Path, show: bool = False) -> None:
+def calibration_color_paths_from_context(
+    ctx: AnalysisContext, show: bool = False
+) -> None:
     """Calibration of color paths for a given fluidflower class and configuration.
 
     Args:
@@ -28,11 +32,15 @@ def calibration_color_paths(cls: type[Rig], path: Path, show: bool = False) -> N
         path: The path to the configuration file.
         show: Whether to display plots during processing.
     """
+    # ! ---- LOAD FROM CONTEXT ----
 
-    config = FluidFlowerConfig(path, require_data=True, require_results=False)
-    config.check("rig", "data", "protocol", "color", "calibration.color")
+    config = ctx.config
+    experiment = ctx.experiment
+    fluidflower = ctx.fluidflower
+    calibration_image_paths = ctx.image_paths
 
     # Mypy type checking
+    config.check("rig", "data", "protocol", "color", "calibration.color")
     assert config.color is not None
     assert config.calibration is not None
     assert config.calibration.color is not None
@@ -43,12 +51,7 @@ def calibration_color_paths(cls: type[Rig], path: Path, show: bool = False) -> N
     assert config.protocol.injection is not None
     assert config.protocol.pressure_temperature is not None
 
-    # ! ---- LOAD EXPERIMENT ----
-    experiment = darsia.ProtocolledExperiment.init_from_config(config)
-
-    # ! ---- LOAD RIG ----
-    fluidflower = cls.load(config.rig.path)
-    fluidflower.load_experiment(experiment)
+    # ! ---- SELECT EMBEDDING AND LABELS ----
 
     embedding = config.calibration.color.color
     assert embedding is not None
@@ -60,13 +63,6 @@ def calibration_color_paths(cls: type[Rig], path: Path, show: bool = False) -> N
     selected_labels = embedding.get_labels(fluidflower)
 
     # ! ---- LOAD IMAGES ----
-
-    calibration_image_paths = select_image_paths(
-        config,
-        experiment,
-        all=False,
-        sub_config=embedding,
-    )
 
     # Cache baseline images for performance
     baseline_sub_config = SimpleNamespace(data=embedding.baseline_data)

--- a/src/darsia/presets/workflows/calibration/calibration_color_to_mass_analysis.py
+++ b/src/darsia/presets/workflows/calibration/calibration_color_to_mass_analysis.py
@@ -4,11 +4,7 @@ from pathlib import Path
 import numpy as np
 
 import darsia
-from darsia.presets.workflows.analysis.analysis_context import (
-    AnalysisContext,
-    select_image_paths,
-)
-from darsia.presets.workflows.analysis.expert_knowledge import ExpertKnowledgeAdapter
+from darsia.presets.workflows.analysis.analysis_context import AnalysisContext
 from darsia.presets.workflows.basis import label_ids_from_image
 from darsia.presets.workflows.calibration.metadata import (
     read_calibration_metadata,
@@ -18,7 +14,6 @@ from darsia.presets.workflows.config.fluidflower_config import FluidFlowerConfig
 from darsia.presets.workflows.heterogeneous_color_to_mass_analysis import (
     HeterogeneousColorToMassAnalysis,
 )
-from darsia.presets.workflows.restoration import build_restoration
 from darsia.presets.workflows.utils.images import load_images_with_cache
 from darsia.signals.color import ColorPathEmbedding
 

--- a/src/darsia/presets/workflows/calibration/calibration_color_to_mass_analysis.py
+++ b/src/darsia/presets/workflows/calibration/calibration_color_to_mass_analysis.py
@@ -4,7 +4,11 @@ from pathlib import Path
 import numpy as np
 
 import darsia
-from darsia.presets.workflows.analysis.analysis_context import select_image_paths
+from darsia.presets.workflows.analysis.analysis_context import (
+    AnalysisContext,
+    select_image_paths,
+)
+from darsia.presets.workflows.analysis.expert_knowledge import ExpertKnowledgeAdapter
 from darsia.presets.workflows.basis import label_ids_from_image
 from darsia.presets.workflows.calibration.metadata import (
     read_calibration_metadata,
@@ -14,6 +18,7 @@ from darsia.presets.workflows.config.fluidflower_config import FluidFlowerConfig
 from darsia.presets.workflows.heterogeneous_color_to_mass_analysis import (
     HeterogeneousColorToMassAnalysis,
 )
+from darsia.presets.workflows.restoration import build_restoration
 from darsia.presets.workflows.utils.images import load_images_with_cache
 from darsia.signals.color import ColorPathEmbedding
 
@@ -64,9 +69,8 @@ def _load_baseline_color_spectrum_for_color_to_mass(
     return baseline_color_spectrum
 
 
-def calibration_color_to_mass_analysis(
-    cls,
-    path: Path,
+def calibration_color_to_mass_analysis_from_context(
+    ctx: AnalysisContext,
     ref_path: Path | None = None,
     reset: bool = False,
     show: bool = False,
@@ -85,12 +89,17 @@ def calibration_color_to_mass_analysis(
         default: Whether to perform default calibration without interactive steps.
 
     """
-    # ! ---- LOAD RUN AND RIG ----
+    # ! ---- LOAD FROM CONTEXT ----
 
-    config = FluidFlowerConfig(path, require_data=True, require_results=False)
-    config.check("color", "rig", "data", "protocol", "calibration.mass")
+    config = ctx.config
+    experiment = ctx.experiment
+    fluidflower = ctx.fluidflower
+    restoration = ctx.restoration
+    expert_knowledge_adapter = ctx.expert_knowledge_adapter
+    calibration_image_paths = ctx.image_paths
 
     # Mypy type checking
+    config.check("color", "rig", "data", "protocol", "calibration.mass")
     assert config.data is not None
     assert config.protocol is not None
     assert config.color is not None
@@ -104,13 +113,6 @@ def calibration_color_to_mass_analysis(
         raise NotImplementedError(
             "calibration.mass currently supports only color path embeddings."
         )
-
-    # ! ---- LOAD EXPERIMENT ----
-    experiment = darsia.ProtocolledExperiment.init_from_config(config)
-
-    # ! ---- LOAD RIG ----
-    fluidflower = cls.load(config.rig.path)
-    fluidflower.load_experiment(experiment)
 
     # ! ---- LOAD COLOR PATHS ----
 
@@ -145,9 +147,6 @@ def calibration_color_to_mass_analysis(
     )
 
     # ! ---- LOAD IMAGES ----
-    calibration_image_paths = select_image_paths(
-        config, experiment, all=False, sub_config=mass_cfg
-    )
 
     # Cache calibration images for performance
     calibration_images: list[darsia.Image] = load_images_with_cache(
@@ -254,17 +253,6 @@ def calibration_color_to_mass_analysis(
         for label, color_path in color_paths.items()
     }
 
-    # ! ---- SIGNAL FUNCTIONS ---- ! #
-
-    # ! ---- POROSITY-INFORMED AVERAGING ---- ! #
-    # TODO: holes in the segmentation?
-    image_porosity = fluidflower.image_porosity
-    restoration = darsia.VolumeAveraging(
-        rev=darsia.REV(size=0.005, img=fluidflower.baseline),
-        mask=image_porosity,
-        # labels=fluidflower.labels,
-    )
-
     # ! ---- FROM COLOR PATH TO MASS ----
 
     experiment_start = experiment.experiment_start
@@ -301,6 +289,7 @@ def calibration_color_to_mass_analysis(
             geometry=fluidflower.geometry,
             restoration=restoration,
             basis=selected_basis,
+            expert_knowledge_adapter=expert_knowledge_adapter,
         )
         color_analysis.color_path_interpretation = color_path_interpretation
 
@@ -314,6 +303,7 @@ def calibration_color_to_mass_analysis(
             geometry=fluidflower.geometry,
             restoration=restoration,
             basis=selected_basis,
+            expert_knowledge_adapter=expert_knowledge_adapter,
         )
     else:
         # Start from scratch
@@ -356,6 +346,7 @@ def calibration_color_to_mass_analysis(
             restoration=restoration,
             ignore_labels=embedding.ignore_labels + ignore_labels,
             basis=selected_basis,
+            expert_knowledge_adapter=expert_knowledge_adapter,
         )
 
     # ! ---- INTERACTIVE CALIBRATION ---- ! #

--- a/src/darsia/presets/workflows/config/calibration.py
+++ b/src/darsia/presets/workflows/config/calibration.py
@@ -106,6 +106,7 @@ class CalibrationConfig:
 
     color: CalibrationColorConfig | None = None
     mass: CalibrationMassConfig | None = None
+    data: TimeData | None = None
 
     def load(
         self,
@@ -136,5 +137,13 @@ class CalibrationConfig:
             )
         except KeyError:
             self.mass = None
+
+        try:
+            self.data = (
+                data_registry.resolve(sec.get("data")) if data_registry else None
+            )
+        except KeyError:
+            warn("No data found for calibration. Use [calibration].data.")
+            self.data = None
 
         return self

--- a/src/darsia/presets/workflows/config/fluidflower_config.py
+++ b/src/darsia/presets/workflows/config/fluidflower_config.py
@@ -268,6 +268,10 @@ class FluidFlowerConfig:
                     "No color embedding registry loaded. Use [color.path.*], "
                     "[color.range.*], or [color.channel.*]."
                 )
+        elif key == "calibration" and (not self.calibration):
+            raise ValueError(
+                "No color calibration entrypoint loaded. Use [calibration]."
+            )
         elif key == "calibration.color" and (
             not self.calibration or not self.calibration.color
         ):
@@ -315,6 +319,7 @@ class FluidFlowerConfig:
                 "analysis",
                 "analysis.data",
                 "analysis.segmentation",
+                "calibration",
                 "color",
                 "calibration.color",
                 "calibration.mass",

--- a/src/darsia/presets/workflows/user_interface_calibration.py
+++ b/src/darsia/presets/workflows/user_interface_calibration.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from darsia.presets.workflows.analysis.analysis_context import prepare_analysis_context
 from darsia.presets.workflows.calibration.calibration_color_paths import (
-    calibration_color_paths,
+    calibration_color_paths_from_context,
     delete_calibration,
 )
 from darsia.presets.workflows.calibration.calibration_color_to_mass_analysis import (
@@ -87,23 +87,23 @@ def preset_calibration(rig=Rig, **kwargs):
         delete_calibration(args.config)
         return
 
+    # Prepare shared context once for all analyses
+    ctx = prepare_analysis_context(
+        cls=rig,
+        path=args.config,
+        all=False,
+        require_color_to_mass=False,
+        section="calibration",
+        require_results=False,
+    )
+
     if args.color_embedding:
-        calibration_color_paths(
-            rig,
-            args.config,
+        calibration_color_paths_from_context(
+            ctx,
             args.show,
         )
 
     if args.mass or args.default_mass:
-        # Prepare shared context once for all analyses
-        ctx = prepare_analysis_context(
-            cls=rig,
-            path=args.config,
-            all=False,
-            require_color_to_mass=False,
-            section="calibration",
-            require_results=False,
-        )
         ref_config = Path(args.ref_config) if args.ref_config else None
         calibration_color_to_mass_analysis_from_context(
             ctx,

--- a/src/darsia/presets/workflows/user_interface_calibration.py
+++ b/src/darsia/presets/workflows/user_interface_calibration.py
@@ -10,12 +10,13 @@ import argparse
 import logging
 from pathlib import Path
 
+from darsia.presets.workflows.analysis.analysis_context import prepare_analysis_context
 from darsia.presets.workflows.calibration.calibration_color_paths import (
     calibration_color_paths,
     delete_calibration,
 )
 from darsia.presets.workflows.calibration.calibration_color_to_mass_analysis import (
-    calibration_color_to_mass_analysis,
+    calibration_color_to_mass_analysis_from_context,
 )
 from darsia.presets.workflows.rig import Rig
 
@@ -94,10 +95,18 @@ def preset_calibration(rig=Rig, **kwargs):
         )
 
     if args.mass or args.default_mass:
+        # Prepare shared context once for all analyses
+        ctx = prepare_analysis_context(
+            cls=rig,
+            path=args.config,
+            all=False,
+            require_color_to_mass=False,
+            section="calibration",
+            require_results=False,
+        )
         ref_config = Path(args.ref_config) if args.ref_config else None
-        calibration_color_to_mass_analysis(
-            rig,
-            args.config,
+        calibration_color_to_mass_analysis_from_context(
+            ctx,
             ref_path=ref_config,
             reset=args.reset,
             show=args.show,

--- a/src/darsia/presets/workflows/user_interface_gui.py
+++ b/src/darsia/presets/workflows/user_interface_gui.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from queue import Empty, Full
 from typing import Any, Callable, Protocol, TypedDict
 
+from darsia.presets.workflows.analysis.analysis_context import prepare_analysis_context
 from darsia.presets.workflows.analysis.progress import (
     AnalysisProgressEvent,
     normalize_progress_event,
@@ -686,6 +687,17 @@ def _run_calibration_workflow(
 
     paths = normalize_paths(config_paths)
     rig_cls = resolve_rig_class(rig_spec)
+
+    # Prepare shared context once for all analyses
+    ctx = prepare_analysis_context(
+        cls=rig_cls,
+        path=paths,
+        all=False,
+        require_color_to_mass=False,
+        section="calibration",
+        require_results=False,
+    )
+
     if options["delete"]:
         delete_calibration(
             paths,
@@ -695,9 +707,8 @@ def _run_calibration_workflow(
     if options["color_embedding"]:
         calibration_color_paths(rig_cls, paths, options["show"])
     if options["mass"] or options["default_mass"]:
-        c2m_analysis_module.calibration_color_to_mass_analysis(
-            rig_cls,
-            paths,
+        c2m_analysis_module.calibration_color_to_mass_analysis_from_context(
+            ctx,
             reset=options["reset"],
             show=options["show"],
             default=options["default_mass"],

--- a/src/darsia/presets/workflows/user_interface_gui.py
+++ b/src/darsia/presets/workflows/user_interface_gui.py
@@ -681,7 +681,7 @@ def _run_calibration_workflow(
         calibration_color_to_mass_analysis as c2m_analysis_module,
     )
     from darsia.presets.workflows.calibration.calibration_color_paths import (
-        calibration_color_paths,
+        calibration_color_paths_from_context,
         delete_calibration,
     )
 
@@ -705,7 +705,7 @@ def _run_calibration_workflow(
         )
         return
     if options["color_embedding"]:
-        calibration_color_paths(rig_cls, paths, options["show"])
+        calibration_color_paths_from_context(ctx, options["show"])
     if options["mass"] or options["default_mass"]:
         c2m_analysis_module.calibration_color_to_mass_analysis_from_context(
             ctx,


### PR DESCRIPTION
Removes hard coded restoration in mass analysis. And provides centralized restoration through Context. Now available for both analysis and (mass) calibration.