### PR TITLE
Refined depth config

### DIFF
--- a/src/darsia/gui/ui/file_dialog.py
+++ b/src/darsia/gui/ui/file_dialog.py
@@ -95,9 +95,10 @@ class FileDialogHelper:
         tuple
             (setting_container, file_edits) - the UI widget and list of line edits
         """
-        setting = setting_dict["key"]
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
         values = self.main_window.settings_factory.get_value(
-            self.main_window.config_dict, setting
+            self.main_window.config_dict, key
         )
         if values is None:
             values = setting_dict.get("default")
@@ -109,7 +110,7 @@ class FileDialogHelper:
         header_container = QWidget()
         header_layout = QHBoxLayout(header_container)
         header_layout.setContentsMargins(0, 0, 0, 0)
-        setting_label = QLabel(setting)
+        setting_label = QLabel(display_name)
         add_button = QPushButton("Add file")
         header_layout.addWidget(setting_label)
         header_layout.addStretch()
@@ -146,7 +147,7 @@ class FileDialogHelper:
             def browse():
                 selected_path, _ = QFileDialog.getOpenFileName(
                     self.main_window,
-                    f"Select file for {setting}",
+                    f"Select file for {display_name}",
                     path_edit.text() if path_edit.text() else "",
                     "All Files (*)",
                 )

--- a/src/darsia/gui/ui/schema/dataclass_introspection.py
+++ b/src/darsia/gui/ui/schema/dataclass_introspection.py
@@ -172,6 +172,7 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
             setting_dict = {
                 "key": key,
                 "type": "group",
+                "name": field.metadata.get("name", None),
                 "help": field.metadata.get("help", None),
                 "link": field.metadata.get("link", None),
                 "active_list_key": field.metadata.get("active_list_key", None),
@@ -182,6 +183,7 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
             setting_dict = {
                 "key": key,
                 "type": widget_type,
+                "name": field.metadata.get("name", None),
                 "help": field.metadata.get("help", None),
                 "link": field.metadata.get("link", None),
                 "options": field.metadata.get("options", None),

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -145,12 +145,14 @@ class SettingsFactory:
         elif setting_type == "fixed_list" and setting_dict.get("list_type") == "string":
             return self.create_fixed_list_string_input(setting_dict)
         elif setting_type == "file":
+            display_name = setting_dict.get("name", setting_dict["key"])
             return self.file_dialog.create_file_chooser(
-                setting_dict["key"], None, False, setting_dict
+                display_name, None, False, setting_dict
             )
         elif setting_type == "folder":
+            display_name = setting_dict.get("name", setting_dict["key"])
             return self.file_dialog.create_file_chooser(
-                setting_dict["key"], None, True, setting_dict
+                display_name, None, True, setting_dict
             )
         elif setting_type == "multi_file":
             return self.file_dialog.create_multi_file_input(setting_dict)
@@ -162,13 +164,14 @@ class SettingsFactory:
 
     def create_simple_input(self, setting_dict):
         """Create a line edit input for numeric or string values."""
-        setting = setting_dict["key"]
-        value = self.get_value(self.main_window.config_dict, setting)
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+        value = self.get_value(self.main_window.config_dict, key)
         if value is None:
             value = setting_dict.get("default")
         setting_container = QWidget()
         setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(setting)
+        setting_label = QLabel(display_name)
         setting_edit = QLineEdit()
         if value is not None:
             setting_edit.setText(str(value))
@@ -185,13 +188,14 @@ class SettingsFactory:
 
     def create_bool_input(self, setting_dict):
         """Create a checkbox input for boolean values."""
-        setting = setting_dict["key"]
-        value = self.get_value(self.main_window.config_dict, setting)
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+        value = self.get_value(self.main_window.config_dict, key)
         if value is None:
             value = setting_dict.get("default")
         setting_container = QWidget()
         setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(setting)
+        setting_label = QLabel(display_name)
         setting_checkbox = QCheckBox()
         if value is not None:
             setting_checkbox.setChecked(bool(value))
@@ -202,13 +206,14 @@ class SettingsFactory:
 
     def create_dropdown_input(self, setting_dict):
         """Create a combobox input with predefined options."""
-        setting = setting_dict["key"]
-        value = self.get_value(self.main_window.config_dict, setting)
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+        value = self.get_value(self.main_window.config_dict, key)
         if value is None:
             value = setting_dict.get("default")
         setting_container = QWidget()
         setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(setting)
+        setting_label = QLabel(display_name)
         options = setting_dict["options"]
         setting_combo = QComboBox()
         setting_combo.addItems([str(option) for option in options])
@@ -226,13 +231,14 @@ class SettingsFactory:
 
     def create_fixed_list_string_input(self, setting_dict):
         """Create a checkbox list for selecting from predefined options."""
-        setting = setting_dict["key"]
-        values = self.get_value(self.main_window.config_dict, setting)
+        key = setting_dict["key"]
+        display_name = setting_dict.get("name", key)
+        values = self.get_value(self.main_window.config_dict, key)
         if values is None:
             values = setting_dict.get("default")
         setting_container = QWidget()
         setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(setting)
+        setting_label = QLabel(display_name)
         setting_layout.addWidget(setting_label)
         options = setting_dict["options"]
         check_boxes = []
@@ -257,9 +263,10 @@ class SettingsFactory:
         """
         key = setting_dict["key"]  # e.g. "corrections.resize"
         name = key.rsplit(".", 1)[-1]
+        display_name = setting_dict.get("name", name)
         active_list_name = setting_dict.get("active_list_key")
 
-        group_box = QGroupBox(name)
+        group_box = QGroupBox(display_name)
         result = {}
 
         if active_list_name is not None:

--- a/src/darsia/presets/workflows/config/depth.py
+++ b/src/darsia/presets/workflows/config/depth.py
@@ -13,19 +13,38 @@ logger = logging.getLogger(__name__)
 class DepthConfig:
     """Depth configuration for the setup."""
 
-    measurements: Path = field(default_factory=Path)
+    measurements: Path = field(
+        default_factory=Path,
+        metadata={
+            "name": "Measurements",
+            "help": "Path to the csv file containing the depth measurements.",
+        },
+    )
     """Path to the csv file containing the depth measurements."""
-    depth_map: Path = field(default_factory=Path)
-    """Path to the depth map file."""
+    depth_map: Path | None = field(
+        default=None,
+        metadata={
+            "name": "Depth map",
+            "help": (
+                "Path to the depth map file. If left empty, computed automatically "
+                "as <results>/setup/depth/depth_map.npz."
+            ),
+            "hidden": True,
+        },
+    )
+    """Path to the depth map file. Computed under `results` if not given."""
 
     def load(self, path: Path, results: Path | None = None) -> "DepthConfig":
         """Load depth config from a toml file from [section]."""
         sec = _get_section_from_toml(path, "depth")
         self.measurements = _get_key(sec, "measurements", required=True, type_=Path)
-        self.depth_map = _get_key(sec, "depth_map", required=False, type_=Path)
-        if not self.depth_map:
-            assert results is not None
-            self.depth_map = results / "setup" / "depth" / "depth_map.npz"
+        default_depth_map = (
+            results / "setup" / "depth" / "depth_map.npz" if results else None
+        )
+        self.depth_map = _get_key(
+            sec, "depth_map", default=default_depth_map, required=False, type_=Path
+        )
+        assert self.depth_map is not None, "results is required if depth_map is not set"
         return self
 
     def error(self):


### PR DESCRIPTION
Two changes:
- If "name" is added to metadata in configs, it is used in the GUI when displaying the property. Fall back to previous behvaior if not provided.
- DepthConfig as example has now metadata.