### PR TITLE
Organize GUI in forms and groups

### DIFF
--- a/src/darsia/gui/ui/file_dialog.py
+++ b/src/darsia/gui/ui/file_dialog.py
@@ -10,6 +10,8 @@ from PySide6.QtWidgets import (
     QWidget,
 )
 
+from .help import build_help_column
+
 
 class FileDialogHelper:
     """Helper for creating file/folder selection UI components."""
@@ -80,21 +82,7 @@ class FileDialogHelper:
         field_layout.addWidget(path_edit, stretch=1)
 
         # Right column: help button or spacer (fixed 40px)
-        right_column = QWidget()
-        right_layout = QHBoxLayout(right_column)
-        right_layout.setContentsMargins(0, 0, 0, 0)
-
-        help_text = setting_dict.get("help") if setting_dict else None
-        link_url = setting_dict.get("link") if setting_dict else None
-        if help_text:
-            from .help import HelpButton
-            help_button = HelpButton(help_text, link_url)
-            right_layout.addWidget(help_button)
-        else:
-            right_layout.addStretch()
-
-        right_column.setFixedWidth(40)
-        field_layout.addWidget(right_column)
+        field_layout.addWidget(build_help_column(setting_dict))
 
         return display_name, field_widget
 
@@ -146,22 +134,7 @@ class FileDialogHelper:
             header_layout.setContentsMargins(0, 0, 0, 0)
             header_layout.setSpacing(4)
             header_layout.addWidget(add_button, stretch=1)
-
-            right_column = QWidget()
-            right_layout = QHBoxLayout(right_column)
-            right_layout.setContentsMargins(0, 0, 0, 0)
-
-            help_text = setting_dict.get("help")
-            link_url = setting_dict.get("link")
-            if help_text:
-                from .help import HelpButton
-                help_button = HelpButton(help_text, link_url)
-                right_layout.addWidget(help_button)
-            else:
-                right_layout.addStretch()
-
-            right_column.setFixedWidth(40)
-            header_layout.addWidget(right_column)
+            header_layout.addWidget(build_help_column(setting_dict))
 
             def add_row(initial_value=""):
                 row_widget = QWidget()
@@ -405,22 +378,7 @@ class FileDialogHelper:
             header_layout.setContentsMargins(0, 0, 0, 0)
             header_layout.setSpacing(4)
             header_layout.addWidget(add_button, stretch=1)
-
-            right_column = QWidget()
-            right_layout = QHBoxLayout(right_column)
-            right_layout.setContentsMargins(0, 0, 0, 0)
-
-            help_text = setting_dict.get("help")
-            link_url = setting_dict.get("link")
-            if help_text:
-                from .help import HelpButton
-                help_button = HelpButton(help_text, link_url)
-                right_layout.addWidget(help_button)
-            else:
-                right_layout.addStretch()
-
-            right_column.setFixedWidth(40)
-            header_layout.addWidget(right_column)
+            header_layout.addWidget(build_help_column(setting_dict))
 
             def add_row(initial_key="", initial_value=""):
                 row_widget = QWidget()

--- a/src/darsia/gui/ui/file_dialog.py
+++ b/src/darsia/gui/ui/file_dialog.py
@@ -86,7 +86,9 @@ class FileDialogHelper:
 
         return display_name, field_widget
 
-    def create_multi_file_input(self, setting_dict, is_directory=False, form_context=None):
+    def create_multi_file_input(
+        self, setting_dict, is_directory=False, form_context=None
+    ):
         """Create a variable-size file/folder list input with add/remove buttons.
 
         Parameters
@@ -128,7 +130,8 @@ class FileDialogHelper:
         if form_context:
             form = form_context["form"]
 
-            # Build composite header widget: [add_button (stretch=1)][help_button_or_spacer (fixed 40px)]
+            # Build composite header widget:
+            # [add_button (stretch=1)][help_button_or_spacer (fixed 40px)]
             header_widget = QWidget()
             header_layout = QHBoxLayout(header_widget)
             header_layout.setContentsMargins(0, 0, 0, 0)
@@ -189,7 +192,8 @@ class FileDialogHelper:
                 row_layout.addWidget(path_edit, stretch=1)
                 row_layout.addWidget(remove_button)
 
-                # Find the correct insertion index: after the header_widget header row, then after last data row
+                # Find the correct insertion index: after the header_widget header row,
+                # then after last data row
                 header_idx, _ = form.getWidgetPosition(header_widget)
                 if file_rows:
                     last_idx, _ = form.getWidgetPosition(file_rows[-1]["widget"])
@@ -211,15 +215,17 @@ class FileDialogHelper:
             # Connect add_button to add_row closure (which will handle form insertion)
             add_button.clicked.connect(lambda: add_row())
 
-            # Return the add_button as the field_widget; build_tab_form will insert the header row.
-            # Once the header is in the form, we can insert data rows (in the deferred pre-fill below).
-            # NOTE: We can't pre-fill data rows here because the header row isn't in the form yet.
-            # Instead, we'll pre-fill them lazily when the GUI is shown (by connecting to a deferred callback).
-            # For now, just return the add_button and file_edits list for save_settings.
+            # Return the add_button as the field_widget; build_tab_form will insert
+            # the header row. Once the header is in the form, we can insert data rows
+            # (in the deferred pre-fill below).
+            # NOTE: We can't pre-fill data rows here because the header row isn't in
+            # the form yet. Instead, we'll pre-fill them lazily when the GUI is shown
+            # (by connecting to a deferred callback). For now, just return the add_button
+            # and file_edits list for save_settings.
 
-            # Actually, to pre-fill, we can use a deferred insertion that runs after the header is added.
-            # The simplest: call add_row() after build_tab_form has had a chance to add the header.
-            # We'll use a QTimer to defer the pre-fill:
+            # Actually, to pre-fill, we can use a deferred insertion that runs after the
+            # header is added. The simplest: call add_row() after build_tab_form has had
+            # a chance to add the header. We'll use a QTimer to defer the pre-fill:
             from PySide6.QtCore import QTimer
 
             def deferred_prefill():
@@ -372,7 +378,8 @@ class FileDialogHelper:
         if form_context:
             form = form_context["form"]
 
-            # Build composite header widget: [add_button (stretch=1)][help_button_or_spacer (fixed 40px)]
+            # Build composite header widget:
+            # [add_button (stretch=1)][help_button_or_spacer (fixed 40px)]
             header_widget = QWidget()
             header_layout = QHBoxLayout(header_widget)
             header_layout.setContentsMargins(0, 0, 0, 0)

--- a/src/darsia/gui/ui/file_dialog.py
+++ b/src/darsia/gui/ui/file_dialog.py
@@ -19,6 +19,41 @@ class FileDialogHelper:
     def __init__(self, main_window):
         self.main_window = main_window
 
+    def _browse_for_path(self, is_directory, title, line_edit):
+        """Open a file/folder dialog and write the selected path into line_edit."""
+        if is_directory:
+            selected = QFileDialog.getExistingDirectory(
+                self.main_window, title, line_edit.text() if line_edit.text() else ""
+            )
+        else:
+            selected, _ = QFileDialog.getOpenFileName(
+                self.main_window,
+                title,
+                line_edit.text() if line_edit.text() else "",
+                "All Files (*)",
+            )
+        if selected:
+            line_edit.setText(selected)
+
+    def _remove_form_row(
+        self,
+        form,
+        row_widget,
+        row_data,
+        row_data_list,
+        removed_value,
+        value_list,
+        refresh_fn,
+    ):
+        """Remove a dynamically-added row from a QFormLayout and its tracking lists."""
+        row_idx, _ = form.getWidgetPosition(row_widget)
+        form.removeRow(row_idx)
+        if row_data in row_data_list:
+            row_data_list.remove(row_data)
+        if removed_value in value_list:
+            value_list.remove(removed_value)
+        refresh_fn()
+
     def create_file_chooser(
         self, display_name, file_filter, is_directory, setting_dict=None
     ):
@@ -159,33 +194,24 @@ class FileDialogHelper:
                 remove_button = QPushButton("Remove")
                 remove_button.setMaximumWidth(80)
 
-                def browse():
-                    if is_directory:
-                        selected_path = QFileDialog.getExistingDirectory(
-                            self.main_window,
-                            f"Select folder for {display_name}",
-                            path_edit.text() if path_edit.text() else "",
-                        )
-                    else:
-                        selected_path, _ = QFileDialog.getOpenFileName(
-                            self.main_window,
-                            f"Select file for {display_name}",
-                            path_edit.text() if path_edit.text() else "",
-                            "All Files (*)",
-                        )
-                    if selected_path:
-                        path_edit.setText(selected_path)
-
                 def remove():
-                    row_idx, _ = form.getWidgetPosition(row_widget)
-                    form.removeRow(row_idx)
-                    if row_data in file_rows:
-                        file_rows.remove(row_data)
-                    if path_edit in file_edits:
-                        file_edits.remove(path_edit)
-                    refresh_remove_buttons()
+                    self._remove_form_row(
+                        form,
+                        row_widget,
+                        row_data,
+                        file_rows,
+                        path_edit,
+                        file_edits,
+                        refresh_remove_buttons,
+                    )
 
-                browse_button.clicked.connect(browse)
+                browse_button.clicked.connect(
+                    lambda: self._browse_for_path(
+                        is_directory,
+                        f"Select {'folder' if is_directory else 'file'} for {display_name}",
+                        path_edit,
+                    )
+                )
                 remove_button.clicked.connect(remove)
 
                 row_layout.addWidget(browse_button)
@@ -278,23 +304,6 @@ class FileDialogHelper:
                 remove_button = QPushButton("Remove")
                 remove_button.setMaximumWidth(80)
 
-                def browse():
-                    if is_directory:
-                        selected_path = QFileDialog.getExistingDirectory(
-                            self.main_window,
-                            f"Select folder for {display_name}",
-                            path_edit.text() if path_edit.text() else "",
-                        )
-                    else:
-                        selected_path, _ = QFileDialog.getOpenFileName(
-                            self.main_window,
-                            f"Select file for {display_name}",
-                            path_edit.text() if path_edit.text() else "",
-                            "All Files (*)",
-                        )
-                    if selected_path:
-                        path_edit.setText(selected_path)
-
                 def remove():
                     row_container.deleteLater()
                     if row_data in file_rows:
@@ -303,7 +312,13 @@ class FileDialogHelper:
                         file_edits.remove(path_edit)
                     refresh_remove_buttons()
 
-                browse_button.clicked.connect(browse)
+                browse_button.clicked.connect(
+                    lambda: self._browse_for_path(
+                        is_directory,
+                        f"Select {'folder' if is_directory else 'file'} for {display_name}",
+                        path_edit,
+                    )
+                )
                 remove_button.clicked.connect(remove)
 
                 row_layout.addWidget(browse_button)
@@ -423,51 +438,39 @@ class FileDialogHelper:
                 remove_button = QPushButton("Remove")
                 remove_button.setMaximumWidth(80)
 
-                def browse_key():
-                    if key_is_directory:
-                        selected = QFileDialog.getExistingDirectory(
-                            self.main_window,
-                            f"Select key (folder) for {display_name}",
-                            key_edit.text() if key_edit.text() else "",
-                        )
-                    else:
-                        selected, _ = QFileDialog.getOpenFileName(
-                            self.main_window,
-                            f"Select key (file) for {display_name}",
-                            key_edit.text() if key_edit.text() else "",
-                            "All Files (*)",
-                        )
-                    if selected:
-                        key_edit.setText(selected)
-
-                def browse_value():
-                    if value_is_directory:
-                        selected = QFileDialog.getExistingDirectory(
-                            self.main_window,
-                            f"Select value (folder) for {display_name}",
-                            value_edit.text() if value_edit.text() else "",
-                        )
-                    else:
-                        selected, _ = QFileDialog.getOpenFileName(
-                            self.main_window,
-                            f"Select value (file) for {display_name}",
-                            value_edit.text() if value_edit.text() else "",
-                            "All Files (*)",
-                        )
-                    if selected:
-                        value_edit.setText(selected)
-
                 def remove():
-                    row_idx, _ = form.getWidgetPosition(row_widget)
-                    form.removeRow(row_idx)
-                    if row_data in row_data_list:
-                        row_data_list.remove(row_data)
-                    if (key_edit, value_edit) in row_pairs:
-                        row_pairs.remove((key_edit, value_edit))
-                    refresh_remove_buttons()
+                    self._remove_form_row(
+                        form,
+                        row_widget,
+                        row_data,
+                        row_data_list,
+                        (key_edit, value_edit),
+                        row_pairs,
+                        refresh_remove_buttons,
+                    )
 
-                key_browse_button.clicked.connect(browse_key)
-                value_browse_button.clicked.connect(browse_value)
+                key_browse_button.clicked.connect(
+                    lambda: self._browse_for_path(
+                        key_is_directory,
+                        (
+                            """Select key """
+                            f"""({"folder" if key_is_directory else "file"}) """
+                            f"""for {display_name}"""
+                        ),
+                        key_edit,
+                    )
+                )
+                value_browse_button.clicked.connect(
+                    lambda: self._browse_for_path(
+                        value_is_directory,
+                        (
+                            """Select value """
+                            f"""({"folder" if value_is_directory else "file"}) """
+                            f"""for {display_name}"""
+                        ),
+                        value_edit,
+                    )
+                )
                 remove_button.clicked.connect(remove)
 
                 row_layout.addWidget(key_browse_button)
@@ -569,40 +572,6 @@ class FileDialogHelper:
                 remove_button = QPushButton("Remove")
                 remove_button.setMaximumWidth(80)
 
-                def browse_key():
-                    if key_is_directory:
-                        selected = QFileDialog.getExistingDirectory(
-                            self.main_window,
-                            f"Select key (folder) for {display_name}",
-                            key_edit.text() if key_edit.text() else "",
-                        )
-                    else:
-                        selected, _ = QFileDialog.getOpenFileName(
-                            self.main_window,
-                            f"Select key (file) for {display_name}",
-                            key_edit.text() if key_edit.text() else "",
-                            "All Files (*)",
-                        )
-                    if selected:
-                        key_edit.setText(selected)
-
-                def browse_value():
-                    if value_is_directory:
-                        selected = QFileDialog.getExistingDirectory(
-                            self.main_window,
-                            f"Select value (folder) for {display_name}",
-                            value_edit.text() if value_edit.text() else "",
-                        )
-                    else:
-                        selected, _ = QFileDialog.getOpenFileName(
-                            self.main_window,
-                            f"Select value (file) for {display_name}",
-                            value_edit.text() if value_edit.text() else "",
-                            "All Files (*)",
-                        )
-                    if selected:
-                        value_edit.setText(selected)
-
                 def remove():
                     row_container.deleteLater()
                     if row_data in row_data_list:
@@ -611,8 +580,28 @@ class FileDialogHelper:
                         row_pairs.remove((key_edit, value_edit))
                     refresh_remove_buttons()
 
-                key_browse_button.clicked.connect(browse_key)
-                value_browse_button.clicked.connect(browse_value)
+                key_browse_button.clicked.connect(
+                    lambda: self._browse_for_path(
+                        key_is_directory,
+                        (
+                            """Select key """
+                            """({'folder' if key_is_directory else 'file'}) """
+                            f"""for {display_name}"""
+                        ),
+                        key_edit,
+                    )
+                )
+                value_browse_button.clicked.connect(
+                    lambda: self._browse_for_path(
+                        value_is_directory,
+                        (
+                            """Select value """
+                            f"""({"folder" if value_is_directory else "file"}) """
+                            f"""for {display_name}"""
+                        ),
+                        value_edit,
+                    )
+                )
                 remove_button.clicked.connect(remove)
 
                 row_layout.addWidget(key_browse_button)

--- a/src/darsia/gui/ui/file_dialog.py
+++ b/src/darsia/gui/ui/file_dialog.py
@@ -20,7 +20,7 @@ class FileDialogHelper:
     def create_file_chooser(
         self, display_name, file_filter, is_directory, setting_dict=None
     ):
-        """Create a file/folder chooser UI element (button + path label).
+        """Create a file/folder chooser UI element (browse button + path edit).
 
         Parameters
         ----------
@@ -32,27 +32,23 @@ class FileDialogHelper:
             If True, opens directory selection dialog; if False, opens file dialog
         setting_dict : dict, optional
             Setting configuration dict with "key" and "default"; when provided,
-            pre-fills the path label from the loaded config or default value.
+            pre-fills the path edit from the loaded config or default value.
 
         Returns
         -------
         tuple
-            (chooser_container, path_label) - the UI widget and the label to update
+            (label_text, field_widget) where field_widget is a composite HBox:
+            [browse_button, path_edit (stretch=1), help_button_or_spacer (fixed 40px)]
         """
         if not file_filter:
             file_filter = "All Files (*)"
 
-        chooser_container = QWidget()
-        chooser_layout = QHBoxLayout(chooser_container)
-        chooser_layout.setContentsMargins(0, 5, 0, 5)
-
         # Browse button
-        browse_button = QPushButton(f"Browse {display_name}")
-        browse_button.setMinimumWidth(200)
+        browse_button = QPushButton("Browse")
+        browse_button.setMaximumWidth(100)
 
-        # Path label to display selected path
-        path_label = QLineEdit("No file chosen")
-        path_label.setStyleSheet("color: white;")
+        # Path edit to display/edit selected path
+        path_edit = QLineEdit("No file chosen")
 
         # Pre-fill from config or default if setting_dict is provided
         if setting_dict is not None:
@@ -62,27 +58,47 @@ class FileDialogHelper:
             if value is None:
                 value = setting_dict.get("default")
             if value:
-                path_label.setText(str(value))
-                path_label.setStyleSheet("color: white;")
+                path_edit.setText(str(value))
 
-        # Store label reference for updating
-        key = display_name.lower().replace(" ", "_")
-        self.main_window.chosen_files[key] = {
-            "path": "",
-            "label": path_label,
-            "is_directory": is_directory,
-            "filter": file_filter,
-        }
+            # Store label reference for updating (backward compatibility with browse_file)
+            key = display_name.lower().replace(" ", "_")
+            self.main_window.chosen_files[key] = {
+                "path": "",
+                "label": path_edit,
+                "is_directory": is_directory,
+                "filter": file_filter,
+            }
+            browse_button.clicked.connect(lambda: self.main_window.browse_file(key))
 
-        # Connect button to file dialog
-        browse_button.clicked.connect(lambda: self.main_window.browse_file(key))
+        # Build composite field widget
+        field_widget = QWidget()
+        field_layout = QHBoxLayout(field_widget)
+        field_layout.setContentsMargins(0, 0, 0, 0)
+        field_layout.setSpacing(4)
 
-        chooser_layout.addWidget(browse_button)
-        chooser_layout.addWidget(path_label)
-        chooser_layout.addStretch()
-        return chooser_container, path_label
+        field_layout.addWidget(browse_button)
+        field_layout.addWidget(path_edit, stretch=1)
 
-    def create_multi_file_input(self, setting_dict, is_directory=False):
+        # Right column: help button or spacer (fixed 40px)
+        right_column = QWidget()
+        right_layout = QHBoxLayout(right_column)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        help_text = setting_dict.get("help") if setting_dict else None
+        link_url = setting_dict.get("link") if setting_dict else None
+        if help_text:
+            from .help import HelpButton
+            help_button = HelpButton(help_text, link_url)
+            right_layout.addWidget(help_button)
+        else:
+            right_layout.addStretch()
+
+        right_column.setFixedWidth(40)
+        field_layout.addWidget(right_column)
+
+        return display_name, field_widget
+
+    def create_multi_file_input(self, setting_dict, is_directory=False, form_context=None):
         """Create a variable-size file/folder list input with add/remove buttons.
 
         Parameters
@@ -91,11 +107,15 @@ class FileDialogHelper:
             Setting configuration dictionary with 'key' field
         is_directory : bool, optional
             If True, opens directory selection dialog; if False, opens file dialog
+        form_context : dict, optional
+            If provided, contains "form" (QFormLayout) for dynamic row insertion/removal.
+            If None, uses internal QVBoxLayout (fallback for backward compatibility).
 
         Returns
         -------
         tuple
-            (setting_container, file_edits) - the UI widget and list of line edits
+            (label_text, field_widget) if form_context is None (internal layout),
+            or (label_text, file_edits_list) if form_context is provided (form-based).
         """
         key = setting_dict["key"]
         display_name = setting_dict.get("name", key)
@@ -105,110 +125,215 @@ class FileDialogHelper:
         if values is None:
             values = setting_dict.get("default")
 
-        setting_container = QWidget()
-        setting_layout = QVBoxLayout(setting_container)
-        setting_layout.setContentsMargins(0, 0, 0, 0)
-
-        header_container = QWidget()
-        header_layout = QHBoxLayout(header_container)
-        header_layout.setContentsMargins(0, 0, 0, 0)
-        setting_label = QLabel(display_name)
-        add_button_text = "Add folder" if is_directory else "Add file"
-        add_button = QPushButton(add_button_text)
-        header_layout.addWidget(setting_label)
-        header_layout.addStretch()
-        header_layout.addWidget(add_button)
-        setting_layout.addWidget(header_container)
-
-        rows_container = QWidget()
-        rows_layout = QVBoxLayout(rows_container)
-        rows_layout.setContentsMargins(0, 0, 0, 0)
-        setting_layout.addWidget(rows_container)
-
         file_edits = []
-        file_rows = []
+        file_rows = []  # Track row data (widget, remove_button)
 
         def refresh_remove_buttons():
             show_remove = len(file_rows) > 1
             for row in file_rows:
                 row["remove_button"].setVisible(show_remove)
 
-        def add_row(initial_value=""):
-            row_container = QWidget()
-            row_layout = QHBoxLayout(row_container)
-            row_layout.setContentsMargins(0, 0, 0, 0)
+        add_button_text = "Add folder" if is_directory else "Add file"
+        add_button = QPushButton(add_button_text)
 
-            browse_button = QPushButton("Browse")
-            browse_button.setMinimumWidth(100)
-            path_edit = QLineEdit()
-            placeholder = (
-                "Select a folder or type a path"
-                if is_directory
-                else "Select a file or type a path"
-            )
-            path_edit.setPlaceholderText(placeholder)
-            if initial_value:
-                path_edit.setText(str(initial_value))
-            remove_button = QPushButton("Remove")
-            remove_button.setMaximumWidth(80)
+        # If form_context provided, use QFormLayout-based insertion
+        if form_context:
+            form = form_context["form"]
 
-            def browse():
-                if is_directory:
-                    selected_path = QFileDialog.getExistingDirectory(
-                        self.main_window,
-                        f"Select folder for {display_name}",
-                        path_edit.text() if path_edit.text() else "",
-                    )
+            def add_row(initial_value=""):
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(0, 0, 0, 0)
+                row_layout.setSpacing(4)
+
+                browse_button = QPushButton("Browse")
+                browse_button.setMaximumWidth(80)
+                path_edit = QLineEdit()
+                placeholder = (
+                    "Select a folder or type a path"
+                    if is_directory
+                    else "Select a file or type a path"
+                )
+                path_edit.setPlaceholderText(placeholder)
+                if initial_value:
+                    path_edit.setText(str(initial_value))
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def browse():
+                    if is_directory:
+                        selected_path = QFileDialog.getExistingDirectory(
+                            self.main_window,
+                            f"Select folder for {display_name}",
+                            path_edit.text() if path_edit.text() else "",
+                        )
+                    else:
+                        selected_path, _ = QFileDialog.getOpenFileName(
+                            self.main_window,
+                            f"Select file for {display_name}",
+                            path_edit.text() if path_edit.text() else "",
+                            "All Files (*)",
+                        )
+                    if selected_path:
+                        path_edit.setText(selected_path)
+
+                def remove():
+                    row_idx, _ = form.getWidgetPosition(row_widget)
+                    form.removeRow(row_idx)
+                    if row_data in file_rows:
+                        file_rows.remove(row_data)
+                    if path_edit in file_edits:
+                        file_edits.remove(path_edit)
+                    refresh_remove_buttons()
+
+                browse_button.clicked.connect(browse)
+                remove_button.clicked.connect(remove)
+
+                row_layout.addWidget(browse_button)
+                row_layout.addWidget(path_edit, stretch=1)
+                row_layout.addWidget(remove_button)
+
+                # Find the correct insertion index: after the add_button header row, then after last data row
+                header_idx, _ = form.getWidgetPosition(add_button)
+                if file_rows:
+                    last_idx, _ = form.getWidgetPosition(file_rows[-1]["widget"])
+                    insert_idx = last_idx + 1
                 else:
-                    selected_path, _ = QFileDialog.getOpenFileName(
-                        self.main_window,
-                        f"Select file for {display_name}",
-                        path_edit.text() if path_edit.text() else "",
-                        "All Files (*)",
-                    )
-                if selected_path:
-                    path_edit.setText(selected_path)
+                    # Insert right after header row
+                    insert_idx = header_idx + 1
 
-            def remove():
-                row_container.deleteLater()
-                if row_data in file_rows:
-                    file_rows.remove(row_data)
-                if path_edit in file_edits:
-                    file_edits.remove(path_edit)
+                form.insertRow(insert_idx, "", row_widget)
+
+                row_data = {
+                    "widget": row_widget,
+                    "remove_button": remove_button,
+                }
+                file_rows.append(row_data)
+                file_edits.append(path_edit)
                 refresh_remove_buttons()
 
-            browse_button.clicked.connect(browse)
-            remove_button.clicked.connect(remove)
+            # Connect add_button to add_row closure (which will handle form insertion)
+            add_button.clicked.connect(lambda: add_row())
 
-            row_layout.addWidget(browse_button)
-            row_layout.addWidget(path_edit)
-            row_layout.addWidget(remove_button)
+            # Return the add_button as the field_widget; build_tab_form will insert the header row.
+            # Once the header is in the form, we can insert data rows (in the deferred pre-fill below).
+            # NOTE: We can't pre-fill data rows here because the header row isn't in the form yet.
+            # Instead, we'll pre-fill them lazily when the GUI is shown (by connecting to a deferred callback).
+            # For now, just return the add_button and file_edits list for save_settings.
 
-            rows_layout.addWidget(row_container)
+            # Actually, to pre-fill, we can use a deferred insertion that runs after the header is added.
+            # The simplest: call add_row() after build_tab_form has had a chance to add the header.
+            # We'll use a QTimer to defer the pre-fill:
+            from PySide6.QtCore import QTimer
 
-            row_data = {
-                "container": row_container,
-                "remove_button": remove_button,
-            }
-            file_rows.append(row_data)
-            file_edits.append(path_edit)
-            refresh_remove_buttons()
+            def deferred_prefill():
+                if isinstance(values, list) and values:
+                    for value in values:
+                        add_row(value)
+                else:
+                    add_row("")
 
-        add_button.clicked.connect(lambda: add_row())
+            QTimer.singleShot(0, deferred_prefill)
 
-        if isinstance(values, list) and values:
-            for value in values:
-                add_row(value)
+            # Return the add_button as the field_widget
+            return display_name, add_button
+
+        # Fallback: use internal QVBoxLayout (backward compat)
         else:
-            add_row("")
+            setting_container = QWidget()
+            setting_layout = QVBoxLayout(setting_container)
+            setting_layout.setContentsMargins(0, 0, 0, 0)
 
-        return setting_container, file_edits
+            header_container = QWidget()
+            header_layout = QHBoxLayout(header_container)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            add_button = QPushButton(add_button_text)
+            header_layout.addStretch()
+            header_layout.addWidget(add_button)
+            setting_layout.addWidget(header_container)
+
+            rows_container = QWidget()
+            rows_layout = QVBoxLayout(rows_container)
+            rows_layout.setContentsMargins(0, 0, 0, 0)
+            setting_layout.addWidget(rows_container)
+
+            def add_row(initial_value=""):
+                row_container = QWidget()
+                row_layout = QHBoxLayout(row_container)
+                row_layout.setContentsMargins(0, 0, 0, 0)
+
+                browse_button = QPushButton("Browse")
+                browse_button.setMinimumWidth(100)
+                path_edit = QLineEdit()
+                placeholder = (
+                    "Select a folder or type a path"
+                    if is_directory
+                    else "Select a file or type a path"
+                )
+                path_edit.setPlaceholderText(placeholder)
+                if initial_value:
+                    path_edit.setText(str(initial_value))
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def browse():
+                    if is_directory:
+                        selected_path = QFileDialog.getExistingDirectory(
+                            self.main_window,
+                            f"Select folder for {display_name}",
+                            path_edit.text() if path_edit.text() else "",
+                        )
+                    else:
+                        selected_path, _ = QFileDialog.getOpenFileName(
+                            self.main_window,
+                            f"Select file for {display_name}",
+                            path_edit.text() if path_edit.text() else "",
+                            "All Files (*)",
+                        )
+                    if selected_path:
+                        path_edit.setText(selected_path)
+
+                def remove():
+                    row_container.deleteLater()
+                    if row_data in file_rows:
+                        file_rows.remove(row_data)
+                    if path_edit in file_edits:
+                        file_edits.remove(path_edit)
+                    refresh_remove_buttons()
+
+                browse_button.clicked.connect(browse)
+                remove_button.clicked.connect(remove)
+
+                row_layout.addWidget(browse_button)
+                row_layout.addWidget(path_edit)
+                row_layout.addWidget(remove_button)
+
+                rows_layout.addWidget(row_container)
+
+                row_data = {
+                    "container": row_container,
+                    "remove_button": remove_button,
+                }
+                file_rows.append(row_data)
+                file_edits.append(path_edit)
+                refresh_remove_buttons()
+
+            add_button.clicked.connect(lambda: add_row())
+
+            if isinstance(values, list) and values:
+                for value in values:
+                    add_row(value)
+            else:
+                add_row("")
+
+            return display_name, file_edits
 
     def create_path_map_input(
         self,
         setting_dict,
         key_is_directory=False,
         value_is_directory=False,
+        form_context=None,
     ):
         """Create a dict[Path, Path] editor with two-column rows (key, value).
 
@@ -220,11 +345,14 @@ class FileDialogHelper:
             If True, key column opens directory selection; if False, file selection
         value_is_directory : bool, optional
             If True, value column opens directory selection; if False, file selection
+        form_context : dict, optional
+            If provided, contains "form" (QFormLayout) for dynamic row insertion/removal.
+            If None, uses internal QVBoxLayout (fallback for backward compatibility).
 
         Returns
         -------
         tuple
-            (setting_container, {"path_map": True, "rows": [(key_edit, value_edit), ...]})
+            (label_text, row_pairs_list) where row_pairs_list is [(key_edit, value_edit), ...].
         """
         key = setting_dict["key"]
         display_name = setting_dict.get("name", key)
@@ -234,136 +362,270 @@ class FileDialogHelper:
         if values is None:
             values = setting_dict.get("default")
 
-        setting_container = QWidget()
-        setting_layout = QVBoxLayout(setting_container)
-        setting_layout.setContentsMargins(0, 0, 0, 0)
-
-        header_container = QWidget()
-        header_layout = QHBoxLayout(header_container)
-        header_layout.setContentsMargins(0, 0, 0, 0)
-        setting_label = QLabel(display_name)
-        add_button = QPushButton("Add row")
-        header_layout.addWidget(setting_label)
-        header_layout.addStretch()
-        header_layout.addWidget(add_button)
-        setting_layout.addWidget(header_container)
-
-        rows_container = QWidget()
-        rows_layout = QVBoxLayout(rows_container)
-        rows_layout.setContentsMargins(0, 0, 0, 0)
-        setting_layout.addWidget(rows_container)
-
         row_pairs = []  # List of (key_edit, value_edit) tuples
-        row_data_list = []
+        row_data_list = []  # Track row data (widget, remove_button)
 
         def refresh_remove_buttons():
             show_remove = len(row_data_list) > 1
             for row in row_data_list:
                 row["remove_button"].setVisible(show_remove)
 
-        def add_row(initial_key="", initial_value=""):
-            row_container = QWidget()
-            row_layout = QHBoxLayout(row_container)
-            row_layout.setContentsMargins(0, 0, 0, 0)
+        add_button = QPushButton("Add row")
 
-            # Key column
-            key_browse_button = QPushButton("Browse")
-            key_browse_button.setMaximumWidth(80)
-            key_edit = QLineEdit()
-            key_placeholder = (
-                "Select folder or type path"
-                if key_is_directory
-                else "Select file or type path"
-            )
-            key_edit.setPlaceholderText(key_placeholder)
-            if initial_key:
-                key_edit.setText(str(initial_key))
+        # If form_context provided, use QFormLayout-based insertion
+        if form_context:
+            form = form_context["form"]
 
-            # Value column
-            value_browse_button = QPushButton("Browse")
-            value_browse_button.setMaximumWidth(80)
-            value_edit = QLineEdit()
-            value_placeholder = (
-                "Select folder or type path"
-                if value_is_directory
-                else "Select file or type path"
-            )
-            value_edit.setPlaceholderText(value_placeholder)
-            if initial_value:
-                value_edit.setText(str(initial_value))
+            def add_row(initial_key="", initial_value=""):
+                row_widget = QWidget()
+                row_layout = QHBoxLayout(row_widget)
+                row_layout.setContentsMargins(0, 0, 0, 0)
+                row_layout.setSpacing(4)
 
-            # Remove button
-            remove_button = QPushButton("Remove")
-            remove_button.setMaximumWidth(80)
+                # Key column
+                key_browse_button = QPushButton("Browse")
+                key_browse_button.setMaximumWidth(80)
+                key_edit = QLineEdit()
+                key_placeholder = (
+                    "Select folder or type path"
+                    if key_is_directory
+                    else "Select file or type path"
+                )
+                key_edit.setPlaceholderText(key_placeholder)
+                if initial_key:
+                    key_edit.setText(str(initial_key))
 
-            def browse_key():
-                if key_is_directory:
-                    selected = QFileDialog.getExistingDirectory(
-                        self.main_window,
-                        f"Select key (folder) for {display_name}",
-                        key_edit.text() if key_edit.text() else "",
-                    )
+                # Value column
+                value_browse_button = QPushButton("Browse")
+                value_browse_button.setMaximumWidth(80)
+                value_edit = QLineEdit()
+                value_placeholder = (
+                    "Select folder or type path"
+                    if value_is_directory
+                    else "Select file or type path"
+                )
+                value_edit.setPlaceholderText(value_placeholder)
+                if initial_value:
+                    value_edit.setText(str(initial_value))
+
+                # Remove button
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def browse_key():
+                    if key_is_directory:
+                        selected = QFileDialog.getExistingDirectory(
+                            self.main_window,
+                            f"Select key (folder) for {display_name}",
+                            key_edit.text() if key_edit.text() else "",
+                        )
+                    else:
+                        selected, _ = QFileDialog.getOpenFileName(
+                            self.main_window,
+                            f"Select key (file) for {display_name}",
+                            key_edit.text() if key_edit.text() else "",
+                            "All Files (*)",
+                        )
+                    if selected:
+                        key_edit.setText(selected)
+
+                def browse_value():
+                    if value_is_directory:
+                        selected = QFileDialog.getExistingDirectory(
+                            self.main_window,
+                            f"Select value (folder) for {display_name}",
+                            value_edit.text() if value_edit.text() else "",
+                        )
+                    else:
+                        selected, _ = QFileDialog.getOpenFileName(
+                            self.main_window,
+                            f"Select value (file) for {display_name}",
+                            value_edit.text() if value_edit.text() else "",
+                            "All Files (*)",
+                        )
+                    if selected:
+                        value_edit.setText(selected)
+
+                def remove():
+                    row_idx, _ = form.getWidgetPosition(row_widget)
+                    form.removeRow(row_idx)
+                    if row_data in row_data_list:
+                        row_data_list.remove(row_data)
+                    if (key_edit, value_edit) in row_pairs:
+                        row_pairs.remove((key_edit, value_edit))
+                    refresh_remove_buttons()
+
+                key_browse_button.clicked.connect(browse_key)
+                value_browse_button.clicked.connect(browse_value)
+                remove_button.clicked.connect(remove)
+
+                row_layout.addWidget(key_browse_button)
+                row_layout.addWidget(key_edit, stretch=1)
+                row_layout.addWidget(value_browse_button)
+                row_layout.addWidget(value_edit, stretch=1)
+                row_layout.addWidget(remove_button)
+
+                # Find the correct insertion index: after the add_button header row
+                header_idx, _ = form.getWidgetPosition(add_button)
+                if row_data_list:
+                    last_idx, _ = form.getWidgetPosition(row_data_list[-1]["widget"])
+                    insert_idx = last_idx + 1
                 else:
-                    selected, _ = QFileDialog.getOpenFileName(
-                        self.main_window,
-                        f"Select key (file) for {display_name}",
-                        key_edit.text() if key_edit.text() else "",
-                        "All Files (*)",
-                    )
-                if selected:
-                    key_edit.setText(selected)
+                    # Insert right after header row
+                    insert_idx = header_idx + 1
 
-            def browse_value():
-                if value_is_directory:
-                    selected = QFileDialog.getExistingDirectory(
-                        self.main_window,
-                        f"Select value (folder) for {display_name}",
-                        value_edit.text() if value_edit.text() else "",
-                    )
-                else:
-                    selected, _ = QFileDialog.getOpenFileName(
-                        self.main_window,
-                        f"Select value (file) for {display_name}",
-                        value_edit.text() if value_edit.text() else "",
-                        "All Files (*)",
-                    )
-                if selected:
-                    value_edit.setText(selected)
+                form.insertRow(insert_idx, "", row_widget)
 
-            def remove():
-                row_container.deleteLater()
-                if row_data in row_data_list:
-                    row_data_list.remove(row_data)
-                if (key_edit, value_edit) in row_pairs:
-                    row_pairs.remove((key_edit, value_edit))
+                row_data = {
+                    "widget": row_widget,
+                    "remove_button": remove_button,
+                }
+                row_data_list.append(row_data)
+                row_pairs.append((key_edit, value_edit))
                 refresh_remove_buttons()
 
-            key_browse_button.clicked.connect(browse_key)
-            value_browse_button.clicked.connect(browse_value)
-            remove_button.clicked.connect(remove)
+            # Connect add_button to add_row closure
+            add_button.clicked.connect(lambda: add_row())
 
-            row_layout.addWidget(key_browse_button)
-            row_layout.addWidget(key_edit)
-            row_layout.addWidget(value_browse_button)
-            row_layout.addWidget(value_edit)
-            row_layout.addWidget(remove_button)
+            # Defer pre-fill until after header row is added to form
+            from PySide6.QtCore import QTimer
 
-            rows_layout.addWidget(row_container)
+            def deferred_prefill():
+                if isinstance(values, dict) and values:
+                    for k, v in values.items():
+                        add_row(k, v)
+                else:
+                    add_row("")
 
-            row_data = {
-                "container": row_container,
-                "remove_button": remove_button,
-            }
-            row_data_list.append(row_data)
-            row_pairs.append((key_edit, value_edit))
-            refresh_remove_buttons()
+            QTimer.singleShot(0, deferred_prefill)
 
-        add_button.clicked.connect(lambda: add_row())
+            # Return the add_button as the field_widget
+            return display_name, add_button
 
-        if isinstance(values, dict) and values:
-            for k, v in values.items():
-                add_row(k, v)
+        # Fallback: use internal QVBoxLayout (backward compat)
         else:
-            add_row("")
+            setting_container = QWidget()
+            setting_layout = QVBoxLayout(setting_container)
+            setting_layout.setContentsMargins(0, 0, 0, 0)
 
-        return setting_container, {"path_map": True, "rows": row_pairs}
+            header_container = QWidget()
+            header_layout = QHBoxLayout(header_container)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            setting_label = QLabel(display_name)
+            add_button = QPushButton("Add row")
+            header_layout.addWidget(setting_label)
+            header_layout.addStretch()
+            header_layout.addWidget(add_button)
+            setting_layout.addWidget(header_container)
+
+            rows_container = QWidget()
+            rows_layout = QVBoxLayout(rows_container)
+            rows_layout.setContentsMargins(0, 0, 0, 0)
+            setting_layout.addWidget(rows_container)
+
+            def add_row(initial_key="", initial_value=""):
+                row_container = QWidget()
+                row_layout = QHBoxLayout(row_container)
+                row_layout.setContentsMargins(0, 0, 0, 0)
+
+                # Key column
+                key_browse_button = QPushButton("Browse")
+                key_browse_button.setMaximumWidth(80)
+                key_edit = QLineEdit()
+                key_placeholder = (
+                    "Select folder or type path"
+                    if key_is_directory
+                    else "Select file or type path"
+                )
+                key_edit.setPlaceholderText(key_placeholder)
+                if initial_key:
+                    key_edit.setText(str(initial_key))
+
+                # Value column
+                value_browse_button = QPushButton("Browse")
+                value_browse_button.setMaximumWidth(80)
+                value_edit = QLineEdit()
+                value_placeholder = (
+                    "Select folder or type path"
+                    if value_is_directory
+                    else "Select file or type path"
+                )
+                value_edit.setPlaceholderText(value_placeholder)
+                if initial_value:
+                    value_edit.setText(str(initial_value))
+
+                # Remove button
+                remove_button = QPushButton("Remove")
+                remove_button.setMaximumWidth(80)
+
+                def browse_key():
+                    if key_is_directory:
+                        selected = QFileDialog.getExistingDirectory(
+                            self.main_window,
+                            f"Select key (folder) for {display_name}",
+                            key_edit.text() if key_edit.text() else "",
+                        )
+                    else:
+                        selected, _ = QFileDialog.getOpenFileName(
+                            self.main_window,
+                            f"Select key (file) for {display_name}",
+                            key_edit.text() if key_edit.text() else "",
+                            "All Files (*)",
+                        )
+                    if selected:
+                        key_edit.setText(selected)
+
+                def browse_value():
+                    if value_is_directory:
+                        selected = QFileDialog.getExistingDirectory(
+                            self.main_window,
+                            f"Select value (folder) for {display_name}",
+                            value_edit.text() if value_edit.text() else "",
+                        )
+                    else:
+                        selected, _ = QFileDialog.getOpenFileName(
+                            self.main_window,
+                            f"Select value (file) for {display_name}",
+                            value_edit.text() if value_edit.text() else "",
+                            "All Files (*)",
+                        )
+                    if selected:
+                        value_edit.setText(selected)
+
+                def remove():
+                    row_container.deleteLater()
+                    if row_data in row_data_list:
+                        row_data_list.remove(row_data)
+                    if (key_edit, value_edit) in row_pairs:
+                        row_pairs.remove((key_edit, value_edit))
+                    refresh_remove_buttons()
+
+                key_browse_button.clicked.connect(browse_key)
+                value_browse_button.clicked.connect(browse_value)
+                remove_button.clicked.connect(remove)
+
+                row_layout.addWidget(key_browse_button)
+                row_layout.addWidget(key_edit)
+                row_layout.addWidget(value_browse_button)
+                row_layout.addWidget(value_edit)
+                row_layout.addWidget(remove_button)
+
+                rows_layout.addWidget(row_container)
+
+                row_data = {
+                    "container": row_container,
+                    "remove_button": remove_button,
+                }
+                row_data_list.append(row_data)
+                row_pairs.append((key_edit, value_edit))
+                refresh_remove_buttons()
+
+            add_button.clicked.connect(lambda: add_row())
+
+            if isinstance(values, dict) and values:
+                for k, v in values.items():
+                    add_row(k, v)
+            else:
+                add_row("")
+
+            return display_name, {"path_map": True, "rows": row_pairs}

--- a/src/darsia/gui/ui/file_dialog.py
+++ b/src/darsia/gui/ui/file_dialog.py
@@ -140,6 +140,29 @@ class FileDialogHelper:
         if form_context:
             form = form_context["form"]
 
+            # Build composite header widget: [add_button (stretch=1)][help_button_or_spacer (fixed 40px)]
+            header_widget = QWidget()
+            header_layout = QHBoxLayout(header_widget)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            header_layout.setSpacing(4)
+            header_layout.addWidget(add_button, stretch=1)
+
+            right_column = QWidget()
+            right_layout = QHBoxLayout(right_column)
+            right_layout.setContentsMargins(0, 0, 0, 0)
+
+            help_text = setting_dict.get("help")
+            link_url = setting_dict.get("link")
+            if help_text:
+                from .help import HelpButton
+                help_button = HelpButton(help_text, link_url)
+                right_layout.addWidget(help_button)
+            else:
+                right_layout.addStretch()
+
+            right_column.setFixedWidth(40)
+            header_layout.addWidget(right_column)
+
             def add_row(initial_value=""):
                 row_widget = QWidget()
                 row_layout = QHBoxLayout(row_widget)
@@ -193,8 +216,8 @@ class FileDialogHelper:
                 row_layout.addWidget(path_edit, stretch=1)
                 row_layout.addWidget(remove_button)
 
-                # Find the correct insertion index: after the add_button header row, then after last data row
-                header_idx, _ = form.getWidgetPosition(add_button)
+                # Find the correct insertion index: after the header_widget header row, then after last data row
+                header_idx, _ = form.getWidgetPosition(header_widget)
                 if file_rows:
                     last_idx, _ = form.getWidgetPosition(file_rows[-1]["widget"])
                     insert_idx = last_idx + 1
@@ -235,8 +258,8 @@ class FileDialogHelper:
 
             QTimer.singleShot(0, deferred_prefill)
 
-            # Return the add_button as the field_widget
-            return display_name, add_button
+            # Return the header_widget (composite: add_button + help) as the field_widget
+            return display_name, header_widget
 
         # Fallback: use internal QVBoxLayout (backward compat)
         else:
@@ -376,6 +399,29 @@ class FileDialogHelper:
         if form_context:
             form = form_context["form"]
 
+            # Build composite header widget: [add_button (stretch=1)][help_button_or_spacer (fixed 40px)]
+            header_widget = QWidget()
+            header_layout = QHBoxLayout(header_widget)
+            header_layout.setContentsMargins(0, 0, 0, 0)
+            header_layout.setSpacing(4)
+            header_layout.addWidget(add_button, stretch=1)
+
+            right_column = QWidget()
+            right_layout = QHBoxLayout(right_column)
+            right_layout.setContentsMargins(0, 0, 0, 0)
+
+            help_text = setting_dict.get("help")
+            link_url = setting_dict.get("link")
+            if help_text:
+                from .help import HelpButton
+                help_button = HelpButton(help_text, link_url)
+                right_layout.addWidget(help_button)
+            else:
+                right_layout.addStretch()
+
+            right_column.setFixedWidth(40)
+            header_layout.addWidget(right_column)
+
             def add_row(initial_key="", initial_value=""):
                 row_widget = QWidget()
                 row_layout = QHBoxLayout(row_widget)
@@ -465,8 +511,8 @@ class FileDialogHelper:
                 row_layout.addWidget(value_edit, stretch=1)
                 row_layout.addWidget(remove_button)
 
-                # Find the correct insertion index: after the add_button header row
-                header_idx, _ = form.getWidgetPosition(add_button)
+                # Find the correct insertion index: after the header_widget header row
+                header_idx, _ = form.getWidgetPosition(header_widget)
                 if row_data_list:
                     last_idx, _ = form.getWidgetPosition(row_data_list[-1]["widget"])
                     insert_idx = last_idx + 1
@@ -499,8 +545,8 @@ class FileDialogHelper:
 
             QTimer.singleShot(0, deferred_prefill)
 
-            # Return the add_button as the field_widget
-            return display_name, add_button
+            # Return the header_widget (composite: add_button + help) as the field_widget
+            return display_name, header_widget
 
         # Fallback: use internal QVBoxLayout (backward compat)
         else:

--- a/src/darsia/gui/ui/help.py
+++ b/src/darsia/gui/ui/help.py
@@ -3,9 +3,11 @@ import webbrowser
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QFrame,
+    QHBoxLayout,
     QLabel,
     QPushButton,
     QVBoxLayout,
+    QWidget,
 )
 
 
@@ -136,3 +138,24 @@ class HelpButton(QPushButton):
         pos = self.mapToGlobal(self.rect().bottomRight())
         self.popup.move(pos.x() - 200, pos.y() + 5)
         self.popup.show()
+
+
+def build_help_column(setting_dict=None) -> QWidget:
+    """Fixed-width (40px) column: a HelpButton if setting_dict has 'help', else a spacer.
+
+    Used as the right-hand column of every field/header row so Browse buttons,
+    value editors, and Add buttons all line up regardless of whether a field has help text.
+    """
+    right_column = QWidget()
+    right_layout = QHBoxLayout(right_column)
+    right_layout.setContentsMargins(0, 0, 0, 0)
+
+    help_text = setting_dict.get("help") if setting_dict else None
+    if help_text:
+        link_url = setting_dict.get("link")
+        right_layout.addWidget(HelpButton(help_text, link_url))
+    else:
+        right_layout.addStretch()
+
+    right_column.setFixedWidth(40)
+    return right_column

--- a/src/darsia/gui/ui/main_window.py
+++ b/src/darsia/gui/ui/main_window.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
     QFileDialog,
+    QFormLayout,
     QHBoxLayout,
     QLabel,
     QLineEdit,
@@ -185,7 +186,10 @@ class MainWindow(QMainWindow):
         # Second pass: save all regular values (non-group dicts),
         # skipping unchecked group sub-inputs.
         for key, value in self.settings_inputs.items():
-            # Skip group dicts (already handled above)
+            # Skip group result dicts (marked with is_group_result)
+            if isinstance(value, dict) and value.get("is_group_result"):
+                continue
+            # Skip group dicts with checkboxes (already handled above)
             if isinstance(value, dict) and "checkbox" in value:
                 continue
             # Skip path_map dicts (handled below)
@@ -390,36 +394,25 @@ class MainWindow(QMainWindow):
         # Iterate through sections in order (dict preserves insertion order in Python 3.7+)
         for section, settings_list in relevant_settings.items():
             # Create a scroll area and container for this section's fields
-            tab_content = QWidget()
-            tab_layout = QVBoxLayout(tab_content)
-            tab_layout.setContentsMargins(0, 0, 0, 0)
+            tab_container = QWidget()
+            tab_form = QFormLayout(tab_container)
+            tab_form.setContentsMargins(0, 0, 0, 0)
 
-            # Add each setting in this section
-            for setting in settings_list:
-                setting_container, setting_edit = (
-                    self.settings_factory.create_setting_edit(setting)
-                )
+            # Create form_context for multi_file/path_map dynamic row insertion
+            form_context = {"form": tab_form}
 
-                # For groups, wrap the group box itself (no extra help button);
-                # for scalars, add help button column.
-                if setting["type"] == "group":
-                    tab_layout.addWidget(setting_container)
-                    self.settings_inputs[setting["key"]] = setting_edit
-                    # Flatten sub-inputs into settings_inputs so they save normally
-                    for sub_key, sub_edit in setting_edit["sub_inputs"].items():
-                        self.settings_inputs[sub_key] = sub_edit
-                else:
-                    wrapped_container = self.settings_factory.wrap_setting_with_help(
-                        setting_container, setting
-                    )
-                    tab_layout.addWidget(wrapped_container)
-                    self.settings_inputs[setting["key"]] = setting_edit
+            # Build rows in the form, handling grouping via group_name metadata
+            self.settings_factory.build_tab_form(
+                tab_form, settings_list, form_context=form_context
+            )
 
-            # Add stretch at the end of the section
-            tab_layout.addStretch()
+            # Add stretch at the end of the section (QFormLayout doesn't auto-stretch rows)
+            tab_form.setRowWrapPolicy(QFormLayout.WrapLongRows)
+            # Push content to top by adding a stretch row at the end
+            tab_form.addItem(QVBoxLayout())
 
             # Add this section as a tab (capitalize section name for display)
-            tabs.addTab(tab_content, section.capitalize())
+            tabs.addTab(tab_container, section.capitalize())
 
         self.settings_layout.addWidget(tabs)
         self.settings_layout.addStretch()

--- a/src/darsia/gui/ui/schema/dataclass_introspection.py
+++ b/src/darsia/gui/ui/schema/dataclass_introspection.py
@@ -169,6 +169,13 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
 
         # Check if this is an Optional[dataclass] field — render as a group
         if is_dataclass(inner_type):
+            # Guard: dataclass-typed fields cannot also carry "group" metadata (would nest boxes)
+            if field.metadata.get("group"):
+                raise ValueError(
+                    f"Field '{key}' is a dataclass (type:'group') but also carries "
+                    f"metadata['group']. Nested QGroupBoxes are not supported. "
+                    f"Remove the 'group' metadata."
+                )
             setting_dict = {
                 "key": key,
                 "type": "group",
@@ -190,6 +197,7 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
                 "default": _field_default(field),
                 "key_is_directory": field.metadata.get("key_is_directory", None),
                 "value_is_directory": field.metadata.get("value_is_directory", None),
+                "group_name": field.metadata.get("group", None),
             }
 
             # For list/tuple types, add the element type label

--- a/src/darsia/gui/ui/schema/dataclass_introspection.py
+++ b/src/darsia/gui/ui/schema/dataclass_introspection.py
@@ -169,7 +169,8 @@ def _build_fields(dataclass_type: type, key_prefix: str) -> list[dict[str, Any]]
 
         # Check if this is an Optional[dataclass] field — render as a group
         if is_dataclass(inner_type):
-            # Guard: dataclass-typed fields cannot also carry "group" metadata (would nest boxes)
+            # Guard: dataclass-typed fields cannot also carry "group" metadata
+            # (would nest boxes)
             if field.metadata.get("group"):
                 raise ValueError(
                     f"Field '{key}' is a dataclass (type:'group') but also carries "

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -98,12 +98,32 @@ class SettingsFactory:
 
         return settings_by_section
 
+    def _get_or_create_group_form(self, group_forms, parent_form, key, title):
+        """Get or create a group QGroupBox with its own QFormLayout.
+
+        key may be a str (top-level group name or standalone multi-row name) or a tuple
+        (nested multi-row box, keyed by (outer_group_name, own_name) to avoid colliding
+        with top-level keys).
+        """
+        if key not in group_forms:
+            box = QGroupBox(title)
+            form = QFormLayout(box)
+            group_forms[key] = form
+            parent_form.addRow(box)  # Spanning row in whichever form this box belongs to
+        return group_forms[key]
+
     def build_tab_form(self, tab_form, settings_list, form_context=None):
         """Build rows in a QFormLayout, handling grouping via group_name metadata.
 
         Multi-row types (multi_file/multi_folder/path_map) are automatically grouped in
         their own titled QGroupBox using the field's display name, ensuring both the header
         and data rows render inside the same box.
+
+        When a multi-row field carries an explicit group_name (e.g., "Input"), the behavior
+        is nested: the outer "Input" group box is created (or reused) at the top level,
+        and the multi-row field's own "Folders" box is created as a spanning row INSIDE
+        the "Input" box's form (not as a sibling at the top level). This creates a
+        visual hierarchy: Input > Folders + Format + Baseline.
 
         Parameters
         ----------
@@ -114,36 +134,39 @@ class SettingsFactory:
         form_context : dict, optional
             Context dict passed to create_setting_edit (contains "form" for multi_file/path_map)
         """
-        # Track group boxes and their nested forms for first-occurrence placement
-        group_forms = {}  # group_name -> QFormLayout
-        group_boxes = {}  # group_name -> QGroupBox
+        group_forms = {}  # key (str | tuple) -> QFormLayout, first-occurrence cache
 
         MULTI_ROW_TYPES = {"multi_file", "multi_folder", "path_map"}
 
         for setting in settings_list:
             setting_type = setting["type"]
             explicit_group = setting.get("group_name")
-            auto_grouped = False
-            group_name = explicit_group
 
-            # Auto-group multi-row types using their display name if no explicit group
-            if not group_name and setting_type in MULTI_ROW_TYPES:
-                group_name = setting.get("name", setting["key"].rsplit(".", 1)[-1])
+            if setting_type in MULTI_ROW_TYPES:
+                own_name = setting.get("name", setting["key"].rsplit(".", 1)[-1])
                 auto_grouped = True
-
-            # Resolve destination form before creating the widget (KEY FIX)
-            if group_name:
-                if group_name not in group_forms:
-                    # First occurrence: create a new group box with its own form
-                    group_box = QGroupBox(group_name)
-                    group_form = QFormLayout(group_box)
-                    group_forms[group_name] = group_form
-                    group_boxes[group_name] = group_box
-                    tab_form.addRow(group_box)  # Spanning row, first-occurrence position
-
-                target_form = group_forms[group_name]
+                if explicit_group:
+                    # Multi-row field with explicit group: create nested structure
+                    # Outer explicit-group box at top level (shared with scalar siblings)
+                    outer_form = self._get_or_create_group_form(
+                        group_forms, tab_form, explicit_group, explicit_group
+                    )
+                    # Inner box for this multi-row field, NESTED inside the outer box's form
+                    target_form = self._get_or_create_group_form(
+                        group_forms, outer_form, (explicit_group, own_name), own_name
+                    )
+                else:
+                    # No explicit group: standalone top-level box
+                    target_form = self._get_or_create_group_form(
+                        group_forms, tab_form, own_name, own_name
+                    )
             else:
-                target_form = tab_form
+                group_name = explicit_group
+                auto_grouped = False
+                target_form = (
+                    self._get_or_create_group_form(group_forms, tab_form, group_name, group_name)
+                    if group_name else tab_form
+                )
 
             # Resolve form_context against the actual destination form (KEY FIX)
             local_form_context = {"form": target_form}
@@ -159,12 +182,16 @@ class SettingsFactory:
                 for sub_key, sub_widget in field_or_result.get("sub_inputs", {}).items():
                     self.main_window.settings_inputs[sub_key] = sub_widget
             # Handle grouped scalar fields and auto-grouped multi-row fields
-            elif group_name:
+            elif auto_grouped and isinstance(field_or_result, dict):
+                # Multi-row field that created its own result dict (backward compat)
+                # Skip adding to form
+                self.main_window.settings_inputs[setting["key"]] = field_or_result
+            elif auto_grouped or explicit_group:
                 # Blank the label for auto-grouped multi-row fields (box title already shows name)
                 row_label = "" if auto_grouped else label_text
                 target_form.addRow(row_label, field_or_result)
                 self.main_window.settings_inputs[setting["key"]] = field_or_result
-            # Handle ungrouped scalar fields (check that field_or_result is a widget, not a dict)
+            # Handle ungrouped scalar fields
             elif isinstance(field_or_result, dict):
                 # This is a result dict from multi_file/path_map in fallback mode (backward compat)
                 # Skip adding to form; the field already created its own layout

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -13,7 +13,7 @@ from PySide6.QtWidgets import (
 )
 
 from .file_dialog import FileDialogHelper
-from .help import HelpButton
+from .help import build_help_column
 from .schema.dataclass_introspection import get_section_fields
 from .schema.section_registry import get_required_sections
 
@@ -202,9 +202,6 @@ class SettingsFactory:
 
     def wrap_setting_with_help(self, setting_container, setting_dict):
         """Wrap a setting container with a dedicated help button column."""
-        help_text = setting_dict.get("help")
-        link_url = setting_dict.get("link")
-
         wrapper = QWidget()
         wrapper_layout = QHBoxLayout(wrapper)
         wrapper_layout.setContentsMargins(0, 0, 0, 0)
@@ -214,17 +211,7 @@ class SettingsFactory:
         wrapper_layout.addWidget(setting_container, stretch=1)
 
         # Right: fixed-width column for help button (or empty space)
-        right_column = QWidget()
-        right_layout = QHBoxLayout(right_column)
-        right_layout.setContentsMargins(0, 0, 0, 0)
-
-        if help_text:
-            help_button = HelpButton(help_text, link_url)
-            right_layout.addWidget(help_button)
-        else:
-            right_layout.addStretch()
-
-        right_column.setFixedWidth(40)
+        right_column = build_help_column(setting_dict)
         wrapper_layout.addWidget(right_column)
 
         return wrapper
@@ -327,20 +314,7 @@ class SettingsFactory:
         field_layout.addWidget(type_label)
 
         # Right column: help button or spacer (fixed 40px)
-        right_column = QWidget()
-        right_layout = QHBoxLayout(right_column)
-        right_layout.setContentsMargins(0, 0, 0, 0)
-
-        help_text = setting_dict.get("help")
-        link_url = setting_dict.get("link")
-        if help_text:
-            help_button = HelpButton(help_text, link_url)
-            right_layout.addWidget(help_button)
-        else:
-            right_layout.addStretch()
-
-        right_column.setFixedWidth(40)
-        field_layout.addWidget(right_column)
+        field_layout.addWidget(build_help_column(setting_dict))
 
         return display_name, field_widget
 
@@ -371,20 +345,7 @@ class SettingsFactory:
         field_layout.addStretch()
 
         # Right column: help button or spacer (fixed 40px)
-        right_column = QWidget()
-        right_layout = QHBoxLayout(right_column)
-        right_layout.setContentsMargins(0, 0, 0, 0)
-
-        help_text = setting_dict.get("help")
-        link_url = setting_dict.get("link")
-        if help_text:
-            help_button = HelpButton(help_text, link_url)
-            right_layout.addWidget(help_button)
-        else:
-            right_layout.addStretch()
-
-        right_column.setFixedWidth(40)
-        field_layout.addWidget(right_column)
+        field_layout.addWidget(build_help_column(setting_dict))
 
         return display_name, field_widget
 
@@ -419,20 +380,7 @@ class SettingsFactory:
         field_layout.addWidget(setting_combo, stretch=1)
 
         # Right column: help button or spacer (fixed 40px)
-        right_column = QWidget()
-        right_layout = QHBoxLayout(right_column)
-        right_layout.setContentsMargins(0, 0, 0, 0)
-
-        help_text = setting_dict.get("help")
-        link_url = setting_dict.get("link")
-        if help_text:
-            help_button = HelpButton(help_text, link_url)
-            right_layout.addWidget(help_button)
-        else:
-            right_layout.addStretch()
-
-        right_column.setFixedWidth(40)
-        field_layout.addWidget(right_column)
+        field_layout.addWidget(build_help_column(setting_dict))
 
         return display_name, field_widget
 
@@ -468,20 +416,7 @@ class SettingsFactory:
         field_layout.addStretch()
 
         # Right column: help button or spacer (fixed 40px)
-        right_column = QWidget()
-        right_layout = QHBoxLayout(right_column)
-        right_layout.setContentsMargins(0, 0, 0, 0)
-
-        help_text = setting_dict.get("help")
-        link_url = setting_dict.get("link")
-        if help_text:
-            help_button = HelpButton(help_text, link_url)
-            right_layout.addWidget(help_button)
-        else:
-            right_layout.addStretch()
-
-        right_column.setFixedWidth(40)
-        field_layout.addWidget(right_column)
+        field_layout.addWidget(build_help_column(setting_dict))
 
         return display_name, field_widget
 

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -3,6 +3,7 @@
 from PySide6.QtWidgets import (
     QCheckBox,
     QComboBox,
+    QFormLayout,
     QGroupBox,
     QHBoxLayout,
     QLabel,
@@ -97,6 +98,81 @@ class SettingsFactory:
 
         return settings_by_section
 
+    def build_tab_form(self, tab_form, settings_list, form_context=None):
+        """Build rows in a QFormLayout, handling grouping via group_name metadata.
+
+        Multi-row types (multi_file/multi_folder/path_map) are automatically grouped in
+        their own titled QGroupBox using the field's display name, ensuring both the header
+        and data rows render inside the same box.
+
+        Parameters
+        ----------
+        tab_form : QFormLayout
+            The target form layout to populate
+        settings_list : list[dict]
+            List of setting dicts from get_section_fields or similar
+        form_context : dict, optional
+            Context dict passed to create_setting_edit (contains "form" for multi_file/path_map)
+        """
+        # Track group boxes and their nested forms for first-occurrence placement
+        group_forms = {}  # group_name -> QFormLayout
+        group_boxes = {}  # group_name -> QGroupBox
+
+        MULTI_ROW_TYPES = {"multi_file", "multi_folder", "path_map"}
+
+        for setting in settings_list:
+            setting_type = setting["type"]
+            explicit_group = setting.get("group_name")
+            auto_grouped = False
+            group_name = explicit_group
+
+            # Auto-group multi-row types using their display name if no explicit group
+            if not group_name and setting_type in MULTI_ROW_TYPES:
+                group_name = setting.get("name", setting["key"].rsplit(".", 1)[-1])
+                auto_grouped = True
+
+            # Resolve destination form before creating the widget (KEY FIX)
+            if group_name:
+                if group_name not in group_forms:
+                    # First occurrence: create a new group box with its own form
+                    group_box = QGroupBox(group_name)
+                    group_form = QFormLayout(group_box)
+                    group_forms[group_name] = group_form
+                    group_boxes[group_name] = group_box
+                    tab_form.addRow(group_box)  # Spanning row, first-occurrence position
+
+                target_form = group_forms[group_name]
+            else:
+                target_form = tab_form
+
+            # Resolve form_context against the actual destination form (KEY FIX)
+            local_form_context = {"form": target_form}
+            label_text, field_or_result = self.create_setting_edit(setting, local_form_context)
+
+            # Handle type:"group" (Optional[dataclass]) fields — label_text is None, field_or_result is dict with "widget"
+            if label_text is None and isinstance(field_or_result, dict) and "widget" in field_or_result:
+                # This is a group_box result dict
+                group_widget = field_or_result.get("widget")
+                if group_widget:
+                    target_form.addRow(group_widget)  # Spanning row
+                self.main_window.settings_inputs[setting["key"]] = field_or_result
+                for sub_key, sub_widget in field_or_result.get("sub_inputs", {}).items():
+                    self.main_window.settings_inputs[sub_key] = sub_widget
+            # Handle grouped scalar fields and auto-grouped multi-row fields
+            elif group_name:
+                # Blank the label for auto-grouped multi-row fields (box title already shows name)
+                row_label = "" if auto_grouped else label_text
+                target_form.addRow(row_label, field_or_result)
+                self.main_window.settings_inputs[setting["key"]] = field_or_result
+            # Handle ungrouped scalar fields (check that field_or_result is a widget, not a dict)
+            elif isinstance(field_or_result, dict):
+                # This is a result dict from multi_file/path_map in fallback mode (backward compat)
+                # Skip adding to form; the field already created its own layout
+                self.main_window.settings_inputs[setting["key"]] = field_or_result
+            else:
+                target_form.addRow(label_text, field_or_result)
+                self.main_window.settings_inputs[setting["key"]] = field_or_result
+
     def wrap_setting_with_help(self, setting_container, setting_dict):
         """Wrap a setting container with a dedicated help button column."""
         help_text = setting_dict.get("help")
@@ -126,8 +202,23 @@ class SettingsFactory:
 
         return wrapper
 
-    def create_setting_edit(self, setting_dict):
-        """Create a new setting edit based on the setting type and options."""
+    def create_setting_edit(self, setting_dict, form_context=None):
+        """Create a new setting edit based on the setting type and options.
+
+        Parameters
+        ----------
+        setting_dict : dict
+            Setting configuration dictionary
+        form_context : dict, optional
+            Context dict with "form" (QFormLayout) for dynamic row insertion (multi_file/path_map).
+
+        Returns
+        -------
+        tuple
+            (label_text, field_widget) for scalar types,
+            (None, result_dict) for type:'group' (result_dict carries widget and metadata),
+            (label_text, edit_widget_or_dict) for file types.
+        """
         setting_type = setting_dict["type"]
         options = setting_dict.get("options")
         free_value_types = ("int", "float", "string", "list")
@@ -155,10 +246,12 @@ class SettingsFactory:
                 display_name, None, True, setting_dict
             )
         elif setting_type == "multi_file":
-            return self.file_dialog.create_multi_file_input(setting_dict)
+            return self.file_dialog.create_multi_file_input(
+                setting_dict, form_context=form_context
+            )
         elif setting_type == "multi_folder":
             return self.file_dialog.create_multi_file_input(
-                setting_dict, is_directory=True
+                setting_dict, is_directory=True, form_context=form_context
             )
         elif setting_type == "path_map":
             key_is_directory = setting_dict.get("key_is_directory", False)
@@ -167,6 +260,7 @@ class SettingsFactory:
                 setting_dict,
                 key_is_directory=key_is_directory,
                 value_is_directory=value_is_directory,
+                form_context=form_context,
             )
         else:
             self.main_window.print_log(
@@ -175,57 +269,110 @@ class SettingsFactory:
             return self.create_simple_input(setting_dict)
 
     def create_simple_input(self, setting_dict):
-        """Create a line edit input for numeric or string values."""
+        """Create a line edit input for numeric or string values.
+
+        Returns (label_text, field_widget) where field_widget is a composite HBox:
+        [setting_edit (stretch=1), type_label, help_button_or_spacer (fixed 40px)]
+        """
         key = setting_dict["key"]
         display_name = setting_dict.get("name", key)
         value = self.get_value(self.main_window.config_dict, key)
         if value is None:
             value = setting_dict.get("default")
-        setting_container = QWidget()
-        setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(display_name)
+
         setting_edit = QLineEdit()
         if value is not None:
             setting_edit.setText(str(value))
+
+        # Build composite field widget with type label and help button
+        field_widget = QWidget()
+        field_layout = QHBoxLayout(field_widget)
+        field_layout.setContentsMargins(0, 0, 0, 0)
+        field_layout.setSpacing(4)
+
+        # Type annotation label
         if setting_dict["type"] == "list":
-            type_label = QLabel(
-                f"({setting_dict['type']}, {setting_dict['list_type']})"
-            )
+            type_label = QLabel(f"({setting_dict['type']}, {setting_dict['list_type']})")
         else:
             type_label = QLabel(f"({setting_dict['type']})")
-        setting_layout.addWidget(setting_label)
-        setting_layout.addWidget(setting_edit)
-        setting_layout.addWidget(type_label)
-        return setting_container, setting_edit
+
+        field_layout.addWidget(setting_edit, stretch=1)
+        field_layout.addWidget(type_label)
+
+        # Right column: help button or spacer (fixed 40px)
+        right_column = QWidget()
+        right_layout = QHBoxLayout(right_column)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        help_text = setting_dict.get("help")
+        link_url = setting_dict.get("link")
+        if help_text:
+            help_button = HelpButton(help_text, link_url)
+            right_layout.addWidget(help_button)
+        else:
+            right_layout.addStretch()
+
+        right_column.setFixedWidth(40)
+        field_layout.addWidget(right_column)
+
+        return display_name, field_widget
 
     def create_bool_input(self, setting_dict):
-        """Create a checkbox input for boolean values."""
+        """Create a checkbox input for boolean values.
+
+        Returns (label_text, field_widget) where field_widget is a composite HBox:
+        [setting_checkbox, type_label, help_button_or_spacer (fixed 40px)]
+        """
         key = setting_dict["key"]
         display_name = setting_dict.get("name", key)
         value = self.get_value(self.main_window.config_dict, key)
         if value is None:
             value = setting_dict.get("default")
-        setting_container = QWidget()
-        setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(display_name)
+
         setting_checkbox = QCheckBox()
         if value is not None:
             setting_checkbox.setChecked(bool(value))
-        setting_layout.addWidget(setting_label)
-        setting_layout.addWidget(setting_checkbox)
-        setting_layout.addWidget(QLabel("(bool)"))
-        return setting_container, setting_checkbox
+
+        # Build composite field widget with type label and help button
+        field_widget = QWidget()
+        field_layout = QHBoxLayout(field_widget)
+        field_layout.setContentsMargins(0, 0, 0, 0)
+        field_layout.setSpacing(4)
+
+        field_layout.addWidget(setting_checkbox)
+        field_layout.addWidget(QLabel("(bool)"))
+        field_layout.addStretch()
+
+        # Right column: help button or spacer (fixed 40px)
+        right_column = QWidget()
+        right_layout = QHBoxLayout(right_column)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        help_text = setting_dict.get("help")
+        link_url = setting_dict.get("link")
+        if help_text:
+            help_button = HelpButton(help_text, link_url)
+            right_layout.addWidget(help_button)
+        else:
+            right_layout.addStretch()
+
+        right_column.setFixedWidth(40)
+        field_layout.addWidget(right_column)
+
+        return display_name, field_widget
 
     def create_dropdown_input(self, setting_dict):
-        """Create a combobox input with predefined options."""
+        """Create a combobox input with predefined options.
+
+        Returns (label_text, field_widget) where field_widget is a composite HBox:
+        [setting_combo (stretch=1), help_button_or_spacer (fixed 40px)]
+        """
         key = setting_dict["key"]
         display_name = setting_dict.get("name", key)
         value = self.get_value(self.main_window.config_dict, key)
         if value is None:
             value = setting_dict.get("default")
-        setting_container = QWidget()
-        setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(display_name)
+
         options = setting_dict["options"]
         setting_combo = QComboBox()
         setting_combo.addItems([str(option) for option in options])
@@ -236,23 +383,52 @@ class SettingsFactory:
             if index >= 0:
                 setting_combo.setCurrentIndex(index)
 
-        setting_layout.addWidget(setting_label)
-        setting_layout.addWidget(setting_combo)
+        # Build composite field widget with help button
+        field_widget = QWidget()
+        field_layout = QHBoxLayout(field_widget)
+        field_layout.setContentsMargins(0, 0, 0, 0)
+        field_layout.setSpacing(4)
 
-        return setting_container, setting_combo
+        field_layout.addWidget(setting_combo, stretch=1)
+
+        # Right column: help button or spacer (fixed 40px)
+        right_column = QWidget()
+        right_layout = QHBoxLayout(right_column)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        help_text = setting_dict.get("help")
+        link_url = setting_dict.get("link")
+        if help_text:
+            help_button = HelpButton(help_text, link_url)
+            right_layout.addWidget(help_button)
+        else:
+            right_layout.addStretch()
+
+        right_column.setFixedWidth(40)
+        field_layout.addWidget(right_column)
+
+        return display_name, field_widget
 
     def create_fixed_list_string_input(self, setting_dict):
-        """Create a checkbox list for selecting from predefined options."""
+        """Create a checkbox list for selecting from predefined options.
+
+        Returns (label_text, field_widget) where field_widget is a composite HBox:
+        [checkbox1, checkbox2, ..., help_button_or_spacer (fixed 40px)]
+        """
         key = setting_dict["key"]
         display_name = setting_dict.get("name", key)
         values = self.get_value(self.main_window.config_dict, key)
         if values is None:
             values = setting_dict.get("default")
-        setting_container = QWidget()
-        setting_layout = QHBoxLayout(setting_container)
-        setting_label = QLabel(display_name)
-        setting_layout.addWidget(setting_label)
+
         options = setting_dict["options"]
+
+        # Build composite field widget with checkboxes and help button
+        field_widget = QWidget()
+        field_layout = QHBoxLayout(field_widget)
+        field_layout.setContentsMargins(0, 0, 0, 0)
+        field_layout.setSpacing(4)
+
         check_boxes = []
         for option in options:
             check_box = QCheckBox(option)
@@ -260,8 +436,27 @@ class SettingsFactory:
             if values is not None:
                 if option in values:
                     check_box.setChecked(True)
-            setting_layout.addWidget(check_box)
-        return setting_container, check_boxes
+            field_layout.addWidget(check_box)
+
+        field_layout.addStretch()
+
+        # Right column: help button or spacer (fixed 40px)
+        right_column = QWidget()
+        right_layout = QHBoxLayout(right_column)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        help_text = setting_dict.get("help")
+        link_url = setting_dict.get("link")
+        if help_text:
+            help_button = HelpButton(help_text, link_url)
+            right_layout.addWidget(help_button)
+        else:
+            right_layout.addStretch()
+
+        right_column.setFixedWidth(40)
+        field_layout.addWidget(right_column)
+
+        return display_name, field_widget
 
     def create_group_input(self, setting_dict):
         """Create a group box for an Optional[dataclass] field.
@@ -272,6 +467,9 @@ class SettingsFactory:
         predating that list). Fields without this metadata render as a plain
         non-checkable box — their data layer doesn't support enable/disable, so no
         checkbox is shown and nothing is written to the TOML for them.
+
+        Returns the group_box widget (to be added as a spanning row in a QFormLayout)
+        and a result dict with sub_inputs and optional checkbox/active_list_key/name.
         """
         key = setting_dict["key"]  # e.g. "corrections.resize"
         name = key.rsplit(".", 1)[-1]
@@ -302,13 +500,18 @@ class SettingsFactory:
                 }
             )
 
-        group_layout = QVBoxLayout(group_box)
+        # Use QFormLayout for sub-fields (same structure as top-level tabs)
+        group_form = QFormLayout(group_box)
         sub_inputs = {}
         for sub_setting in setting_dict["fields"]:
-            sub_container, sub_edit = self.create_setting_edit(sub_setting)
-            wrapped = self.wrap_setting_with_help(sub_container, sub_setting)
-            group_layout.addWidget(wrapped)
-            sub_inputs[sub_setting["key"]] = sub_edit
+            label_text, field_widget = self.create_setting_edit(sub_setting)
+            group_form.addRow(label_text, field_widget)
+            sub_inputs[sub_setting["key"]] = field_widget
         result["sub_inputs"] = sub_inputs
 
-        return group_box, result
+        # Return (None, group_dict) where group_dict carries the group_box and metadata.
+        # display_settings will check if the label is None to detect this case.
+        # Mark as a group result so save_settings can identify it.
+        result["widget"] = group_box
+        result["is_group_result"] = True
+        return None, result

--- a/src/darsia/gui/ui/settings.py
+++ b/src/darsia/gui/ui/settings.py
@@ -8,7 +8,6 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
-    QVBoxLayout,
     QWidget,
 )
 
@@ -109,7 +108,9 @@ class SettingsFactory:
             box = QGroupBox(title)
             form = QFormLayout(box)
             group_forms[key] = form
-            parent_form.addRow(box)  # Spanning row in whichever form this box belongs to
+            parent_form.addRow(
+                box
+            )  # Spanning row in whichever form this box belongs to
         return group_forms[key]
 
     def build_tab_form(self, tab_form, settings_list, form_context=None):
@@ -132,7 +133,8 @@ class SettingsFactory:
         settings_list : list[dict]
             List of setting dicts from get_section_fields or similar
         form_context : dict, optional
-            Context dict passed to create_setting_edit (contains "form" for multi_file/path_map)
+            Context dict passed to create_setting_edit
+                (contains "form" for multi_file/path_map)
         """
         group_forms = {}  # key (str | tuple) -> QFormLayout, first-occurrence cache
 
@@ -164,22 +166,34 @@ class SettingsFactory:
                 group_name = explicit_group
                 auto_grouped = False
                 target_form = (
-                    self._get_or_create_group_form(group_forms, tab_form, group_name, group_name)
-                    if group_name else tab_form
+                    self._get_or_create_group_form(
+                        group_forms, tab_form, group_name, group_name
+                    )
+                    if group_name
+                    else tab_form
                 )
 
             # Resolve form_context against the actual destination form (KEY FIX)
             local_form_context = {"form": target_form}
-            label_text, field_or_result = self.create_setting_edit(setting, local_form_context)
+            label_text, field_or_result = self.create_setting_edit(
+                setting, local_form_context
+            )
 
-            # Handle type:"group" (Optional[dataclass]) fields — label_text is None, field_or_result is dict with "widget"
-            if label_text is None and isinstance(field_or_result, dict) and "widget" in field_or_result:
+            # Handle type:"group" (Optional[dataclass]) fields — label_text is None,
+            # field_or_result is dict with "widget"
+            if (
+                label_text is None
+                and isinstance(field_or_result, dict)
+                and "widget" in field_or_result
+            ):
                 # This is a group_box result dict
                 group_widget = field_or_result.get("widget")
                 if group_widget:
                     target_form.addRow(group_widget)  # Spanning row
                 self.main_window.settings_inputs[setting["key"]] = field_or_result
-                for sub_key, sub_widget in field_or_result.get("sub_inputs", {}).items():
+                for sub_key, sub_widget in field_or_result.get(
+                    "sub_inputs", {}
+                ).items():
                     self.main_window.settings_inputs[sub_key] = sub_widget
             # Handle grouped scalar fields and auto-grouped multi-row fields
             elif auto_grouped and isinstance(field_or_result, dict):
@@ -187,13 +201,15 @@ class SettingsFactory:
                 # Skip adding to form
                 self.main_window.settings_inputs[setting["key"]] = field_or_result
             elif auto_grouped or explicit_group:
-                # Blank the label for auto-grouped multi-row fields (box title already shows name)
+                # Blank the label for auto-grouped multi-row fields
+                # (box title already shows name)
                 row_label = "" if auto_grouped else label_text
                 target_form.addRow(row_label, field_or_result)
                 self.main_window.settings_inputs[setting["key"]] = field_or_result
             # Handle ungrouped scalar fields
             elif isinstance(field_or_result, dict):
-                # This is a result dict from multi_file/path_map in fallback mode (backward compat)
+                # This is a result dict from multi_file/path_map in fallback mode
+                # (backward compat)
                 # Skip adding to form; the field already created its own layout
                 self.main_window.settings_inputs[setting["key"]] = field_or_result
             else:
@@ -224,7 +240,8 @@ class SettingsFactory:
         setting_dict : dict
             Setting configuration dictionary
         form_context : dict, optional
-            Context dict with "form" (QFormLayout) for dynamic row insertion (multi_file/path_map).
+            Context dict with "form" (QFormLayout) for dynamic row insertion
+                (multi_file/path_map).
 
         Returns
         -------
@@ -306,7 +323,9 @@ class SettingsFactory:
 
         # Type annotation label
         if setting_dict["type"] == "list":
-            type_label = QLabel(f"({setting_dict['type']}, {setting_dict['list_type']})")
+            type_label = QLabel(
+                f"({setting_dict['type']}, {setting_dict['list_type']})"
+            )
         else:
             type_label = QLabel(f"({setting_dict['type']})")
 

--- a/src/darsia/presets/workflows/config/data.py
+++ b/src/darsia/presets/workflows/config/data.py
@@ -35,6 +35,7 @@ class DataConfig:
                 """Add/remove folders using the list editor."""
             ),
             "widget": "multi_folder",
+            "group": "Input",
         },
     )
     """Paths to folders containing image data."""
@@ -44,6 +45,7 @@ class DataConfig:
             "name": "Format",
             "help": "Image file format/extension.",
             "options": ["JPG", "PNG", "TIF", "TIFF", "BMP"],
+            "group": "Input",
         },
     )
     """Format of the image data (e.g., 'JPG', 'PNG')."""
@@ -57,6 +59,7 @@ class DataConfig:
         metadata={
             "name": "Baseline image",
             "help": "Path to the baseline image file.",
+            "group": "Input",
         },
     )
     """Path to the baseline image."""
@@ -71,6 +74,7 @@ class DataConfig:
             "name": "Results folder",
             "help": "Path to the folder where results are stored.",
             "widget": "folder",
+            "group": "Output",
         },
     )
     """Path to the results folder."""
@@ -89,6 +93,7 @@ class DataConfig:
         metadata={
             "name": "Use cache",
             "help": "Whether to cache read/processed images under the results folder.",
+            "group": "Output",
         },
     )
     """Whether to use the cache folder for reading/writing cached images."""

--- a/src/darsia/presets/workflows/config/protocols.py
+++ b/src/darsia/presets/workflows/config/protocols.py
@@ -25,45 +25,50 @@ class ProtocolsConfig:
             ),
             "widget": "path_map",
             "key_is_directory": True,
+            "group": "Imaging",
         },
     )
     """Per-folder mapping from data folder to imaging protocol file, or (file, sheet)."""
-    injection: Path | tuple[Path, str] | None = field(
-        default=None,
-        metadata={
-            "name": "Injection protocol",
-            "help": "Path to the injection-protocol file, or [file, sheet].",
-            "widget": "file",
-        },
-    )
-    """Path to the injection protocol file or (file, sheet)."""
     blacklist: Path | tuple[Path, str] | None = field(
         default=None,
         metadata={
             "name": "Blacklist",
             "help": "Path to a file listing images to exclude, or [file, sheet].",
             "widget": "file",
+            "group": "Imaging",
         },
     )
     """Path to the blacklist protocol file or (file, sheet)."""
-    pressure_temperature: Path | tuple[Path, str] | None = field(
-        default=None,
-        metadata={
-            "name": "Pressure/Temperature protocol",
-            "help": "Path to the pressure-temperature protocol file, or [file, sheet].",
-            "widget": "file",
-        },
-    )
-    """Path to the pressure-temperature protocol file or (file, sheet)."""
     imaging_mode: str = field(
         default="exif",
         metadata={
             "name": "Imaging mode",
             "help": "Datetime extraction mode for imaging protocol setup.",
             "options": ["exif", "ctime"],
+            "group": "Imaging",
         },
     )
     """Datetime extraction mode for imaging protocol setup: 'exif' or 'ctime'."""
+    injection: Path | tuple[Path, str] | None = field(
+        default=None,
+        metadata={
+            "name": "Injection protocol",
+            "help": "Path to the injection-protocol file, or [file, sheet].",
+            "widget": "file",
+            "group": "Experiment",
+        },
+    )
+    """Path to the injection protocol file or (file, sheet)."""
+    pressure_temperature: Path | tuple[Path, str] | None = field(
+        default=None,
+        metadata={
+            "name": "Pressure/Temperature protocol",
+            "help": "Path to the pressure-temperature protocol file, or [file, sheet].",
+            "widget": "file",
+            "group": "Experiment",
+        },
+    )
+    """Path to the pressure-temperature protocol file or (file, sheet)."""
 
     def _parse_protocol_value(
         self, value: str | Path | list[str] | tuple[str, str]

--- a/tests/unit/gui/test_metadata_keywords.py
+++ b/tests/unit/gui/test_metadata_keywords.py
@@ -502,7 +502,8 @@ class TestNameMetadata:
             "fields": [],
         }
 
-        group_box, result = factory.create_group_input(setting_dict)
+        label_text, result = factory.create_group_input(setting_dict)
+        group_box = result.get("widget")
         qtbot.addWidget(group_box)
 
         # Should use the last segment of the key

--- a/tests/unit/gui/test_metadata_keywords.py
+++ b/tests/unit/gui/test_metadata_keywords.py
@@ -296,8 +296,13 @@ class TestOptionsMetadata:
             "default": "a",
         }
 
-        container, widget = factory.create_dropdown_input(setting_dict)
-        qtbot.addWidget(container)
+        label_text, field_widget = factory.create_dropdown_input(setting_dict)
+        qtbot.addWidget(field_widget)
+
+        # field_widget is a composite HBox; find the QComboBox inside
+        combos = field_widget.findChildren(QComboBox)
+        assert len(combos) > 0
+        widget = combos[0]
 
         # Should be a QComboBox
         assert isinstance(widget, QComboBox)
@@ -316,8 +321,13 @@ class TestOptionsMetadata:
             "default": 1,
         }
 
-        container, widget = factory.create_dropdown_input(setting_dict)
-        qtbot.addWidget(container)
+        label_text, field_widget = factory.create_dropdown_input(setting_dict)
+        qtbot.addWidget(field_widget)
+
+        # field_widget is a composite HBox; find the QComboBox inside
+        combos = field_widget.findChildren(QComboBox)
+        assert len(combos) > 0
+        widget = combos[0]
 
         assert isinstance(widget, QComboBox)
         assert widget.count() == 5
@@ -375,9 +385,12 @@ class TestActiveListKeyMetadata:
             ],
         }
 
-        group_box, result = factory.create_group_input(setting_dict)
+        label_text, result = factory.create_group_input(setting_dict)
+        group_box = result.get("widget")
         qtbot.addWidget(group_box)
 
+        # label_text should be None for groups
+        assert label_text is None
         # Should be checkable
         assert group_box.isCheckable()
         # Result dict should have checkbox info
@@ -396,7 +409,8 @@ class TestActiveListKeyMetadata:
             ],
         }
 
-        group_box, result = factory.create_group_input(setting_dict)
+        label_text, result = factory.create_group_input(setting_dict)
+        group_box = result.get("widget")
         qtbot.addWidget(group_box)
 
         # Should NOT be checkable
@@ -426,14 +440,11 @@ class TestNameMetadata:
             "name": "Display Name",
         }
 
-        container, widget = factory.create_simple_input(setting_dict)
-        qtbot.addWidget(container)
+        label_text, field_widget = factory.create_simple_input(setting_dict)
+        qtbot.addWidget(field_widget)
 
-        # Find the label
-        labels = container.findChildren(QLabel)
-        assert len(labels) > 0
-        # First label should have the display name
-        assert labels[0].text() == "Display Name"
+        # Label is now returned as a string
+        assert label_text == "Display Name"
 
     def test_simple_input_fallback_to_key(self, qtbot):
         """Simple input should fallback to key when name absent."""
@@ -443,13 +454,11 @@ class TestNameMetadata:
             "type": "string",
         }
 
-        container, widget = factory.create_simple_input(setting_dict)
-        qtbot.addWidget(container)
+        label_text, field_widget = factory.create_simple_input(setting_dict)
+        qtbot.addWidget(field_widget)
 
-        labels = container.findChildren(QLabel)
-        assert len(labels) > 0
-        # Should use the key
-        assert labels[0].text() == "test.field"
+        # Label is now returned as a string; should fall back to key
+        assert label_text == "test.field"
 
     def test_bool_input_uses_name_label(self, qtbot):
         """Bool input should use name as label when present."""
@@ -460,12 +469,11 @@ class TestNameMetadata:
             "name": "Enable Feature",
         }
 
-        container, widget = factory.create_bool_input(setting_dict)
-        qtbot.addWidget(container)
+        label_text, field_widget = factory.create_bool_input(setting_dict)
+        qtbot.addWidget(field_widget)
 
-        labels = container.findChildren(QLabel)
-        assert len(labels) > 0
-        assert labels[0].text() == "Enable Feature"
+        # Label is now returned as a string
+        assert label_text == "Enable Feature"
 
     def test_group_uses_name_for_title(self, qtbot):
         """Group box should use name as title when present."""
@@ -477,9 +485,12 @@ class TestNameMetadata:
             "fields": [],
         }
 
-        group_box, result = factory.create_group_input(setting_dict)
+        label_text, result = factory.create_group_input(setting_dict)
+        group_box = result.get("widget")
         qtbot.addWidget(group_box)
 
+        # label_text should be None for group types
+        assert label_text is None
         assert group_box.title() == "Sub Configuration"
 
     def test_group_fallback_to_key_segment(self, qtbot):


### PR DESCRIPTION
Aim at clustering items and better alignment.
Introduces:
- "group" keyword in metadata.
- forms used in displaying settings
- explicit groups for multi-row objects, i.e., using nested groups for multi-row objects inside groups

Also centralizes:
- helper buttons
- browse/remove for file dialogues