### PR TITLE
Temporary fix of None relative color

### DIFF
--- a/src/darsia/presets/workflows/config/corrections.py
+++ b/src/darsia/presets/workflows/config/corrections.py
@@ -407,7 +407,9 @@ class CorrectionsConfig:
                 self.inactive[name] = parsed
 
         relative_color_sec = sec.get("relative_color", self.relative_color)
-        if isinstance(relative_color_sec, bool):
+        if relative_color_sec is None:
+            self.relative_color = False
+        elif isinstance(relative_color_sec, bool):
             self.relative_color = relative_color_sec
         elif isinstance(relative_color_sec, dict):
             self.relative_color = RelativeColorCorrectionConfig().load(


### PR DESCRIPTION
Relative color correction currently supports (too) many types. This will need to be fixed later. This PR just makes the default case (None) compatible and runnable.